### PR TITLE
[#3] Add extended help target (make makbet-help)

### DIFF
--- a/examples/test-scenario1/Makefile
+++ b/examples/test-scenario1/Makefile
@@ -19,8 +19,8 @@ GENERIC_TASK_SCRIPT := $(MAKBET_PATH)/examples/test-scenario1/tasks/generic_task
 # All tasks required to run scenario from test-scenario1/Makefile file.
 #
 
-.PHONY: help
-help::
+.PHONY: scenario-help
+scenario-help::
 	@echo ""
 	@echo "All targets defined in $(CURDIR)/$(firstword $(MAKEFILE_LIST)):"
 	@echo ""

--- a/examples/test-scenario2/ver-A/Makefile
+++ b/examples/test-scenario2/ver-A/Makefile
@@ -19,8 +19,8 @@ WORK_DIR := /tmp/makbet/test-scenario2/ver-A
 # All tasks required to run scenario from test-scenario2/ver-A/Makefile file.
 #
 
-.PHONY: help
-help::
+.PHONY: scenario-help
+scenario-help::
 	@echo ""
 	@echo "All targets defined in $(CURDIR)/$(firstword $(MAKEFILE_LIST)):"
 	@echo ""

--- a/examples/test-scenario2/ver-B/Makefile
+++ b/examples/test-scenario2/ver-B/Makefile
@@ -75,8 +75,8 @@ EXEC_CMD := $(MAKBET_TASKS_DIR)/common/exec-cmd.sh
 # All tasks required to run scenario from test-scenario2/ver-B/Makefile file.
 #
 
-.PHONY: help
-help::
+.PHONY: scenario-help
+scenario-help::
 	@echo ""
 	@echo "All targets defined in $(CURDIR)/$(firstword $(MAKEFILE_LIST)):"
 	@echo ""

--- a/makbet.mk
+++ b/makbet.mk
@@ -373,9 +373,9 @@ $(MAKBET_EVENTS_CFG_DIR)/$(strip $(1)).terminated.cfg: $(foreach d,$(2),$(MAKBET
 			$(MAKBET_EVENTS_CSV_HEADER)) ; \
 	fi
 
-#
-.PHONY: help
-help::
+# Add entry to scenario-help target.
+.PHONY: scenario-help
+scenario-help::
 	@echo -e "  $(strip $(1))\t- Call target $(strip $(1)) (dependencies: $(strip $(2)))"
 
 # If MAKBET_VERBOSE=2 printing task's script path (if any) immediately
@@ -457,7 +457,6 @@ PHONY: .show-profiles-csv-dir
 	@env | grep --color=never -P '^MAKBET_[0-9A-Z_]*='
 
 
-# This is makbet-clean target. One of basic makbet targets.
 .PHONY: makbet-clean
 makbet-clean:
 	@-rm -rf $(MAKBET_DOT_DIR)
@@ -465,7 +464,6 @@ makbet-clean:
 	@-rm -rf $(MAKBET_PROFILES_DIR)
 
 
-# This is makbet-version target. One of basic makbet targets.
 .PHONY: makbet-version
 makbet-version:
 	@echo ""
@@ -473,28 +471,9 @@ makbet-version:
 	@echo ""
 
 
-# This is help target. One of basic makbet targets (see also DEFAULT_GOAL on the top).
-.PHONY: help
-help:: makbet-version
-	@echo "  \"What's done, is done.\" - William Shakespeare, Macbeth.                   "
+.PHONY: makbet-help
+makbet-help: main-help
 	@echo ""
-	@echo "Usage: make [TARGET]                                                          "
-	@echo ""
-	@echo "All makbet's basic targets defined in $(MAKBET_PATH)/makbet.mk:               "
-	@echo ""
-	@echo "  help                            - Show makbet's help message (taken from    "
-	@echo "                                    makbet.mk file) as first, then append the "
-	@echo "                                    help message from scenario makefile (if   "
-	@echo "                                    exists). This is the default target.      "
-	@echo "  makbet-clean                    - Clean entire makbet's internal dir        "
-	@echo "                                    (\$$MAKBET_PATH/.makbet/).                "
-	@echo "  makbet-version                  - Print makbet's version only.              "
-	@echo ""
-	@echo "  Examples:                                                                   "
-	@echo "           make                                                               "
-	@echo "           make help                                                          "
-	@echo "           make makbet-version                                                "
-	@echo "                                                                              "
 	@echo "All makbet's special targets defined in $(MAKBET_PATH)/makbet.mk:             "
 	@echo ""
 	@echo "  .show-makbet-dir                - Show entire content of makbet's internal  "
@@ -538,6 +517,55 @@ help:: makbet-version
 	@echo "           make .show-makbet-dir                                              "
 	@echo "           make .show-summary-profiles-csv-file MAKBET_CSV=1 MAKBET_PROFILES=1"
 	@echo ""
+	@exit 0
+
+
+.PHONY: main-help
+main-help: makbet-version
+	@echo "  \"What's done, is done.\" - William Shakespeare, Macbeth.                   "
+	@echo ""
+	@echo "Usage: make [TARGET]                                                          "
+	@echo ""
+	@echo "All makbet's basic targets defined in $(MAKBET_PATH)/makbet.mk:               "
+	@echo ""
+	@echo "  help                            - Show main makbet's help message as first  "
+	@echo "                                    then append the help messages of all tasks"
+	@echo "                                    defined in scenario's Makefile. This is   "
+	@echo "                                    the default target.                       "
+	@echo "  scenario-help                   - Show only scenario's help message (it is  "
+	@echo "                                    generated dynamically based on all tasks  "
+	@echo "                                    defined in scenario's Makefile file).     "
+	@echo "  makbet-help                     - Show main makbet's help message (same as  "
+	@echo "                                    \"make help\" above) then append extended "
+	@echo "                                    help message."
+	@echo "                                    containing all special makbet's targets.  "
+	@echo "  makbet-clean                    - Clean entire makbet's internal dir        "
+	@echo "                                    (\$$MAKBET_PATH/.makbet/).                "
+	@echo "  makbet-version                  - Print makbet's version only.              "
+	@echo ""
+	@echo "  Examples:                                                                   "
+	@echo "           make                                                               "
+	@echo "           make help                                                          "
+	@echo "           make scenario-help                                                 "
+	@echo "           make makbet-help                                                   "
+	@echo "           make makbet-clean                                                  "
+	@echo "           make makbet-version                                                "
+
+
+# This is scenario-help target (the whole scenario-specific help message).
+# If execution directory is MAKBET_PATH then the only allowed makefile at
+# this level is Makefile -> makbet.mk symlink.
+# Therefore scenario-help target is empty here. This is not valid in scenario's
+# directory where help message will be generated dynamically based on all tasks
+# defined in scenario's Makefile file.
+.PHONY: scenario-help
+scenario-help::
+	@#
+
+
+# This is makbet's main help target (see also the DEFAULT_GOAL at the top).
+.PHONY: help
+help: main-help scenario-help
 
 
 # The end


### PR DESCRIPTION
Redesign help system.

- make / make help - will print makbet's version + so-called main
  makbet's help message if execution path is MAKBET_PATH. If command
  was issued in scenario's directory help messages of all tasks will
  be added to output automatically.
- make makbet-help - will print makbet's version + so-called main
  makbet's help message + makbet's specific help message containing
  description of all internal makbet's targets. Execution directory
  is not important here.
- make scenario-help - will print only help messages of all tasks
  defined in scenario's Makefile file. It works only in scenario's
  directory.

Resolve #3.