### PR TITLE
[#13] Handle MAKBET_VERBOSE in all scripts

### DIFF
--- a/examples/test-scenario1/tasks/generic_task.sh
+++ b/examples/test-scenario1/tasks/generic_task.sh
@@ -12,7 +12,12 @@ echo "EXIT_CODE (\${1}) = ${EXIT_CODE}"
 # Wait ${SLEEP} seconds.
 sleep "${SLEEP}"
 
-echo "Script ${0} completed." && exit "${EXIT_CODE}"
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
+
+exit "${EXIT_CODE}"
 
 
 # The end

--- a/examples/test-scenario2/tasks/build-doxygen.sh
+++ b/examples/test-scenario2/tasks/build-doxygen.sh
@@ -18,7 +18,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/examples/test-scenario2/tasks/build-git.sh
+++ b/examples/test-scenario2/tasks/build-git.sh
@@ -15,7 +15,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/examples/test-scenario2/tasks/build-kcov.sh
+++ b/examples/test-scenario2/tasks/build-kcov.sh
@@ -18,7 +18,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/examples/test-scenario2/tasks/build-make.sh
+++ b/examples/test-scenario2/tasks/build-make.sh
@@ -16,7 +16,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/examples/test-scenario2/tasks/build-python.sh
+++ b/examples/test-scenario2/tasks/build-python.sh
@@ -16,7 +16,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/lib/tasks/common/check-dirs.sh
+++ b/lib/tasks/common/check-dirs.sh
@@ -15,7 +15,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/lib/tasks/common/check-files.sh
+++ b/lib/tasks/common/check-files.sh
@@ -15,7 +15,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/lib/tasks/common/create-dir-structure.sh
+++ b/lib/tasks/common/create-dir-structure.sh
@@ -8,7 +8,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/lib/tasks/common/download-file.sh
+++ b/lib/tasks/common/download-file.sh
@@ -10,7 +10,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/lib/tasks/common/exec-cmd.sh
+++ b/lib/tasks/common/exec-cmd.sh
@@ -8,7 +8,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/lib/tasks/common/show-uname.sh
+++ b/lib/tasks/common/show-uname.sh
@@ -8,7 +8,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/lib/tasks/common/show-uptime.sh
+++ b/lib/tasks/common/show-uptime.sh
@@ -8,7 +8,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/lib/tasks/common/uncompress-tgz-file.sh
+++ b/lib/tasks/common/uncompress-tgz-file.sh
@@ -9,7 +9,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/lib/tasks/common/uncompress-txz-file.sh
+++ b/lib/tasks/common/uncompress-txz-file.sh
@@ -9,7 +9,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/lib/tasks/common/uncompress-zip-file.sh
+++ b/lib/tasks/common/uncompress-zip-file.sh
@@ -9,7 +9,10 @@ function main() {
 
 main "$@"
 
-echo "Script ${0} completed."
+if (( "${MAKBET_VERBOSE}" >= 1 ))
+then
+    echo "Script ${0} completed."
+fi
 
 
 # The end

--- a/makbet.mk
+++ b/makbet.mk
@@ -38,7 +38,7 @@ MAKBET_PROFILES_CSV_DIR := $(MAKBET_PROFILES_DIR)/csv
 # Handling CLI input: MAKBET_VERBOSE param.
 #
 ifndef MAKBET_VERBOSE
-  MAKBET_VERBOSE := 0
+  export MAKBET_VERBOSE := 0
 endif
 ifeq ($(MAKBET_VERBOSE), 0)
   _v := 0


### PR DESCRIPTION
Print extra debug message if MAKBET_VERBOSE >= 1 (this variable can
be passed directly as cli option or exported elsewhere but has to be
available in the environment).  By default export MAKBET_VERBOSE=0
variable.  Adapt all scripts (not only the files inside .../lib/*
directory structure but all examples as well).

Resolve #13.