### PR TITLE
[#24] Fix "02.toolchain-basic" example

### DIFF
--- a/examples/02.toolchain-basic/Makefile
+++ b/examples/02.toolchain-basic/Makefile
@@ -140,35 +140,35 @@ $(eval $(call TASK_template, \
 $(eval $(call TASK_template, \
 	build-doxygen, "Build doxygen inside its source dir", \
 	check-all-src-dirs, \
-	$(MAKBET_PATH)/examples/lib/tasks/02.toolchain/commonbuild-doxygen.sh, \
+	$(MAKBET_PATH)/examples/lib/tasks/02.toolchain/common/build-doxygen.sh, \
 		$(WORK_DIR)/doxygen/doxygen-Release_1_8_18/ \
 ))
 
 $(eval $(call TASK_template, \
 	build-git, "Build git inside its source dir", \
 	build-doxygen, \
-	$(MAKBET_PATH)/examples/lib/tasks/02.toolchain/commonbuild-git.sh, \
+	$(MAKBET_PATH)/examples/lib/tasks/02.toolchain/common/build-git.sh, \
 		$(WORK_DIR)/git/git-2.27.0/ \
 ))
 
 $(eval $(call TASK_template, \
 	build-kcov, "Build kcov inside its source dir", \
 	build-git, \
-	$(MAKBET_PATH)/examples/lib/tasks/02.toolchain/commonbuild-kcov.sh, \
+	$(MAKBET_PATH)/examples/lib/tasks/02.toolchain/common/build-kcov.sh, \
 		$(WORK_DIR)/kcov/kcov-38/ \
 ))
 
 $(eval $(call TASK_template, \
 	build-make, "Build GNU make inside its source dir", \
 	build-kcov, \
-	$(MAKBET_PATH)/examples/lib/tasks/02.toolchain/commonbuild-make.sh, \
+	$(MAKBET_PATH)/examples/lib/tasks/02.toolchain/common/build-make.sh, \
 		$(WORK_DIR)/make/make-4.3/ \
 ))
 
 $(eval $(call TASK_template, \
 	build-python, "Build python inside its source dir", \
 	build-make, \
-	$(MAKBET_PATH)/examples/lib/tasks/02.toolchain/commonbuild-python.sh, \
+	$(MAKBET_PATH)/examples/lib/tasks/02.toolchain/common/build-python.sh, \
 		$(WORK_DIR)/python/Python-3.9.0b4/ \
 ))
 


### PR DESCRIPTION
Add missing "/" path separator ("commonbuild" -> "common/build").

Fix #24.
