### PR TITLE
[#39] Add *.dot files to all docs/examples/* dirs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -180,13 +180,14 @@ results which can be used for further processing:
 Below graph picture has been rendered, by
 `edotor <https://edotor.net/>`_ online **DOT** editor, based on above
 ``digraph`` code
-(`01.dummy <https://github.com/skaluzka/makbet/tree/master/examples/01.dummy>`_
+(`01.dummy <https://github.com/skaluzka/makbet/tree/master/examples/01.dummy/Makefile>`_
 example, target ``all``).
 
 .. image:: docs/examples/01.dummy/results.png
     :align: center
 
-| Results for all **makbet's** examples can be found
+| The **DOT** files togehter with corresponding **png** images, for all
+  **makbet's** examples, can be found
   `here <https://github.com/skaluzka/makbet/tree/master/docs/examples/>`_.
 
 |

--- a/docs/examples/01.dummy/results.dot
+++ b/docs/examples/01.dummy/results.dot
@@ -1,0 +1,22 @@
+
+digraph {
+
+	"all" -> "task-F";
+	"INIT";
+	"task-A" -> "INIT";
+	"task-B1" -> "task-A";
+	"task-B2" -> "task-A";
+	"task-B3" -> "task-A";
+	"task-B4" -> "task-A";
+	"task-B5" -> "task-A";
+	"task-C" -> "task-B2";
+	"task-C" -> "task-B3";
+	"task-D" -> "task-C";
+	"task-E" -> "task-B1";
+	"task-E" -> "task-B4";
+	"task-E" -> "task-B5";
+	"task-E" -> "task-D";
+	"task-F" -> "task-E";
+
+}
+

--- a/docs/examples/02.toolchain-basic/results.dot
+++ b/docs/examples/02.toolchain-basic/results.dot
@@ -1,0 +1,45 @@
+
+digraph {
+
+	"all" -> "print-all-versions";
+	"build-all" -> "build-doxygen";
+	"build-all" -> "build-git";
+	"build-all" -> "build-kcov";
+	"build-all" -> "build-make";
+	"build-all" -> "build-python";
+	"build-doxygen" -> "check-all-src-dirs";
+	"build-git" -> "build-doxygen";
+	"build-kcov" -> "build-git";
+	"build-make" -> "build-kcov";
+	"build-python" -> "build-make";
+	"check-all-src-dirs" -> "unpack-doxygen-src";
+	"check-all-src-dirs" -> "unpack-git-src";
+	"check-all-src-dirs" -> "unpack-kcov-src";
+	"check-all-src-dirs" -> "unpack-make-src";
+	"check-all-src-dirs" -> "unpack-python-src";
+	"fetch-doxygen-src" -> "prepare-workdir-structure";
+	"fetch-git-src" -> "prepare-workdir-structure";
+	"fetch-kcov-src" -> "prepare-workdir-structure";
+	"fetch-make-src" -> "prepare-workdir-structure";
+	"fetch-python-src" -> "prepare-workdir-structure";
+	"INIT";
+	"prepare-workdir-structure" -> "INIT";
+	"print-all-versions" -> "build-all";
+	"print-all-versions" -> "print-doxygen-version";
+	"print-all-versions" -> "print-git-version";
+	"print-all-versions" -> "print-kcov-version";
+	"print-all-versions" -> "print-make-version";
+	"print-all-versions" -> "print-python-version";
+	"print-doxygen-version" -> "build-doxygen";
+	"print-git-version" -> "build-git";
+	"print-kcov-version" -> "build-kcov";
+	"print-make-version" -> "build-make";
+	"print-python-version" -> "build-python";
+	"unpack-doxygen-src" -> "fetch-doxygen-src";
+	"unpack-git-src" -> "fetch-git-src";
+	"unpack-kcov-src" -> "fetch-kcov-src";
+	"unpack-make-src" -> "fetch-make-src";
+	"unpack-python-src" -> "fetch-python-src";
+
+}
+

--- a/docs/examples/02.toolchain-complex/results.dot
+++ b/docs/examples/02.toolchain-complex/results.dot
@@ -1,0 +1,38 @@
+
+digraph {
+
+	"build-all" -> "build-doxygen";
+	"build-all" -> "build-git";
+	"build-all" -> "build-kcov";
+	"build-all" -> "build-make";
+	"build-all" -> "build-python";
+	"build-doxygen" -> "check-all-src-dirs";
+	"build-git" -> "build-doxygen";
+	"build-kcov" -> "build-git";
+	"build-make" -> "build-kcov";
+	"build-python" -> "build-make";
+	"check-all-src-dirs" -> "unpack-doxygen-src";
+	"check-all-src-dirs" -> "unpack-git-src";
+	"check-all-src-dirs" -> "unpack-kcov-src";
+	"check-all-src-dirs" -> "unpack-make-src";
+	"check-all-src-dirs" -> "unpack-python-src";
+	"fetch-doxygen-src" -> "prepare-workdir-structure";
+	"fetch-git-src" -> "prepare-workdir-structure";
+	"fetch-kcov-src" -> "prepare-workdir-structure";
+	"fetch-make-src" -> "prepare-workdir-structure";
+	"fetch-python-src" -> "prepare-workdir-structure";
+	"INIT";
+	"prepare-workdir-structure" -> "INIT";
+	"print-doxygen-version" -> "build-doxygen";
+	"print-git-version" -> "build-git";
+	"print-kcov-version" -> "build-kcov";
+	"print-make-version" -> "build-make";
+	"print-python-version" -> "build-python";
+	"unpack-doxygen-src" -> "fetch-doxygen-src";
+	"unpack-git-src" -> "fetch-git-src";
+	"unpack-kcov-src" -> "fetch-kcov-src";
+	"unpack-make-src" -> "fetch-make-src";
+	"unpack-python-src" -> "fetch-python-src";
+
+}
+

--- a/docs/examples/03.ping-dns-servers/results.dot
+++ b/docs/examples/03.ping-dns-servers/results.dot
@@ -1,0 +1,13 @@
+
+digraph {
+
+	"INIT";
+	"ping1111" -> "INIT";
+	"ping8844" -> "INIT";
+	"ping8888" -> "INIT";
+	"ping-all" -> "ping1111";
+	"ping-all" -> "ping8844";
+	"ping-all" -> "ping8888";
+
+}
+


### PR DESCRIPTION
Since now documentation directory for every makbet's example will
contain missing results.dot file as well.

Resolve #39.
