### PR TITLE
[#44] Fix several syntax issues in generic-task.sh

### DIFF
--- a/examples/01.dummy/tasks/generic-task.sh
+++ b/examples/01.dummy/tasks/generic-task.sh
@@ -5,11 +5,11 @@ set -eu
 readonly SLEEP=${1:-0}
 readonly EXIT_CODE=${2:-0}
 
-echo "Script params:"
-echo "SLEEP (\${0}) = ${SLEEP}"
-echo "EXIT_CODE (\${1}) = ${EXIT_CODE}"
+echo "Script opts:"
+echo "PATH (\${0}) = ${0}"
+echo "SLEEP (\${1}) = ${SLEEP}"
+echo "EXIT_CODE (\${2}) = ${EXIT_CODE}"
 
-# Wait ${SLEEP} seconds.
 sleep "${SLEEP}"
 
 if (( "${MAKBET_VERBOSE}" >= 1 ))


### PR DESCRIPTION
Correct numbering for SLEEP and EXIT_CODE variables.  Remove misleading
comment above sleep command.  Add extra PATH line printing the script
path (the value of ${0} variable).

Fix #44.
