### PR TITLE
[#46] Fix path bug for MAKBET_TASK_TOTAL variable

### DIFF
--- a/makbet.mk
+++ b/makbet.mk
@@ -28,7 +28,7 @@ MAKBET_TASK_COUNTER := 0
 #
 # Total task counter per scenario.
 #
-MAKBET_TASK_TOTAL := $(shell grep -c eval $(CURDIR)/$(firstword $(MAKEFILE_LIST)))
+MAKBET_TASK_TOTAL := $(shell grep -c eval $(CURDIR)/$(notdir $(firstword $(MAKEFILE_LIST))))
 
 #
 # Handling makbet's version.


### PR DESCRIPTION
Use $(notdir ...) GNU make function for extracting the file name
from $(firstword $(MAKEFILE_LIST)) before concatenation with $(CURDIR)
variable.

Fix #46.
