### PR TITLE
[#52] Split lines in DOT output

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -171,26 +171,40 @@ results which can be used for further processing:
 
     digraph {
 
-    	node [shape=box];
+        node [shape=box];
 
-    	"all" -> "task-F";
-    	"INIT";
-    	"task-A" -> "INIT";
-    	"task-B1" -> "task-A";
-    	"task-B2" -> "task-A";
-    	"task-B3" -> "task-A";
-    	"task-B4" -> "task-A";
-    	"task-B5" -> "task-A";
-    	"task-C" -> "task-B2";
-    	"task-C" -> "task-B3";
-    	"task-D" -> "task-C";
-    	"task-E" -> "task-B1";
-    	"task-E" -> "task-B4";
-    	"task-E" -> "task-B5";
-    	"task-E" -> "task-D";
-    	"task-F" -> "task-E";
+        "all" -> "task-F";
+
+        "INIT";
+
+        "task-A" -> "INIT";
+
+        "task-B1" -> "task-A";
+
+        "task-B2" -> "task-A";
+
+        "task-B3" -> "task-A";
+
+        "task-B4" -> "task-A";
+
+        "task-B5" -> "task-A";
+
+        "task-C" -> "task-B2";
+        "task-C" -> "task-B3";
+
+        "task-D" -> "task-C";
+
+        "task-E" -> "task-B1";
+        "task-E" -> "task-B4";
+        "task-E" -> "task-B5";
+        "task-E" -> "task-D";
+
+        "task-F" -> "task-E";
+
 
     }
+
+
 
     [user@localhost 01.dummy]$
 

--- a/docs/examples/01.dummy/results.dot
+++ b/docs/examples/01.dummy/results.dot
@@ -4,21 +4,33 @@ digraph {
 	node [shape=box];
 
 	"all" -> "task-F";
+
 	"INIT";
+
 	"task-A" -> "INIT";
+
 	"task-B1" -> "task-A";
+
 	"task-B2" -> "task-A";
+
 	"task-B3" -> "task-A";
+
 	"task-B4" -> "task-A";
+
 	"task-B5" -> "task-A";
+
 	"task-C" -> "task-B2";
 	"task-C" -> "task-B3";
+
 	"task-D" -> "task-C";
+
 	"task-E" -> "task-B1";
 	"task-E" -> "task-B4";
 	"task-E" -> "task-B5";
 	"task-E" -> "task-D";
+
 	"task-F" -> "task-E";
+
 
 }
 

--- a/docs/examples/02.toolchain-basic/results.dot
+++ b/docs/examples/02.toolchain-basic/results.dot
@@ -4,44 +4,70 @@ digraph {
 	node [shape=box];
 
 	"all" -> "print-all-versions";
+
 	"build-all" -> "build-doxygen";
 	"build-all" -> "build-git";
 	"build-all" -> "build-kcov";
 	"build-all" -> "build-make";
 	"build-all" -> "build-python";
+
 	"build-doxygen" -> "check-all-src-dirs";
+
 	"build-git" -> "build-doxygen";
+
 	"build-kcov" -> "build-git";
+
 	"build-make" -> "build-kcov";
+
 	"build-python" -> "build-make";
+
 	"check-all-src-dirs" -> "unpack-doxygen-src";
 	"check-all-src-dirs" -> "unpack-git-src";
 	"check-all-src-dirs" -> "unpack-kcov-src";
 	"check-all-src-dirs" -> "unpack-make-src";
 	"check-all-src-dirs" -> "unpack-python-src";
+
 	"fetch-doxygen-src" -> "prepare-workdir-structure";
+
 	"fetch-git-src" -> "prepare-workdir-structure";
+
 	"fetch-kcov-src" -> "prepare-workdir-structure";
+
 	"fetch-make-src" -> "prepare-workdir-structure";
+
 	"fetch-python-src" -> "prepare-workdir-structure";
+
 	"INIT";
+
 	"prepare-workdir-structure" -> "INIT";
+
 	"print-all-versions" -> "build-all";
 	"print-all-versions" -> "print-doxygen-version";
 	"print-all-versions" -> "print-git-version";
 	"print-all-versions" -> "print-kcov-version";
 	"print-all-versions" -> "print-make-version";
 	"print-all-versions" -> "print-python-version";
+
 	"print-doxygen-version" -> "build-doxygen";
+
 	"print-git-version" -> "build-git";
+
 	"print-kcov-version" -> "build-kcov";
+
 	"print-make-version" -> "build-make";
+
 	"print-python-version" -> "build-python";
+
 	"unpack-doxygen-src" -> "fetch-doxygen-src";
+
 	"unpack-git-src" -> "fetch-git-src";
+
 	"unpack-kcov-src" -> "fetch-kcov-src";
+
 	"unpack-make-src" -> "fetch-make-src";
+
 	"unpack-python-src" -> "fetch-python-src";
+
 
 }
 

--- a/docs/examples/02.toolchain-complex/results.dot
+++ b/docs/examples/02.toolchain-complex/results.dot
@@ -8,33 +8,57 @@ digraph {
 	"build-all" -> "build-kcov";
 	"build-all" -> "build-make";
 	"build-all" -> "build-python";
+
 	"build-doxygen" -> "check-all-src-dirs";
+
 	"build-git" -> "build-doxygen";
+
 	"build-kcov" -> "build-git";
+
 	"build-make" -> "build-kcov";
+
 	"build-python" -> "build-make";
+
 	"check-all-src-dirs" -> "unpack-doxygen-src";
 	"check-all-src-dirs" -> "unpack-git-src";
 	"check-all-src-dirs" -> "unpack-kcov-src";
 	"check-all-src-dirs" -> "unpack-make-src";
 	"check-all-src-dirs" -> "unpack-python-src";
+
 	"fetch-doxygen-src" -> "prepare-workdir-structure";
+
 	"fetch-git-src" -> "prepare-workdir-structure";
+
 	"fetch-kcov-src" -> "prepare-workdir-structure";
+
 	"fetch-make-src" -> "prepare-workdir-structure";
+
 	"fetch-python-src" -> "prepare-workdir-structure";
+
 	"INIT";
+
 	"prepare-workdir-structure" -> "INIT";
+
 	"print-doxygen-version" -> "build-doxygen";
+
 	"print-git-version" -> "build-git";
+
 	"print-kcov-version" -> "build-kcov";
+
 	"print-make-version" -> "build-make";
+
 	"print-python-version" -> "build-python";
+
 	"unpack-doxygen-src" -> "fetch-doxygen-src";
+
 	"unpack-git-src" -> "fetch-git-src";
+
 	"unpack-kcov-src" -> "fetch-kcov-src";
+
 	"unpack-make-src" -> "fetch-make-src";
+
 	"unpack-python-src" -> "fetch-python-src";
+
 
 }
 

--- a/docs/examples/03.ping-dns-servers/results.dot
+++ b/docs/examples/03.ping-dns-servers/results.dot
@@ -4,12 +4,17 @@ digraph {
 	node [shape=box];
 
 	"INIT";
+
 	"ping1111" -> "INIT";
+
 	"ping8844" -> "INIT";
+
 	"ping8888" -> "INIT";
+
 	"ping-all" -> "ping1111";
 	"ping-all" -> "ping8844";
 	"ping-all" -> "ping8888";
+
 
 }
 

--- a/makbet.mk
+++ b/makbet.mk
@@ -302,13 +302,14 @@ define __save_dot_file =
 	. $(1) && \
 		if [ -z "$$$${TASK_DEPS}" ] ; \
 		then \
-			cmd='echo -e "\t\"$$$${TASK_NAME}\";" >> $(strip $(2))' && \
+			cmd='echo -e "\t\"$$$${TASK_NAME}\";\n" >> $(strip $(2))' && \
 				eval $$$${cmd} ; \
 		else \
 			cmd='for t in $$$${TASK_DEPS}; \
 				do \
 					echo -e "\t\"$$$${TASK_NAME}\" -> \"$$$${t}\";" >> $(strip $(2)) ; \
-				done' && \
+				done ; \
+				echo "" >> $(strip $(2))' && \
 				eval $$$${cmd} ; \
 		fi
 endef


### PR DESCRIPTION
Group dependencies (lines) in DOT output pear each task.

Resolve #52.
