### PR TITLE
[#69] Improve reading makbet's version

### DIFF
--- a/core/__get_makbet_version
+++ b/core/__get_makbet_version
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -u
+
+
+set +e
+if [ -d "${MAKBET_PATH}/.git" ]
+then
+    git describe --all --long 2> /dev/null
+else
+    cat "${MAKBET_PATH}/VERSION"
+fi
+set -e
+
+
+# The end

--- a/makbet.mk
+++ b/makbet.mk
@@ -35,9 +35,7 @@ MAKBET_TASK_TOTAL := $(shell \
 #
 # Handling makbet's version.
 #
-MAKBET_VERSION := $(shell \
-  git describe --all --long 2> /dev/null || cat $(MAKBET_PATH)/VERSION \
-)
+MAKBET_VERSION := $(shell $(MAKBET_CORE_DIR)/__get_makbet_version)
 
 #
 # All internal makbet dirs.


### PR DESCRIPTION
Add new script - __get_makbet_version to core/ directory and use it
in makbet.mk.  Don's use "git describe command" if .git/ directory
was not found in MAKBET_PATH location.  This will prevent fetching
wrong sha1 for makbet's version in case makbet has been unpacked
inside other's project clone directory.

Fix #69.
