### PR TITLE
[#99] Rename .show-summary-dot-file makbet's task

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -165,12 +165,12 @@ easily saved or redirected to file.  This can be achieved by passing
 
   [user@localhost 01.dummy]$
 
-Special **makbet's** target ``.show-summary-dot-file`` will display **DOT**
+Special **makbet's** target ``.show-merged-dot-results`` will display **DOT**
 results which can be used for further processing:
 
 ::
 
-  [user@localhost 01.dummy]$ make .show-summary-dot-file
+  [user@localhost 01.dummy]$ make .show-merged-dot-results
 
   digraph {
 

--- a/makbet.mk
+++ b/makbet.mk
@@ -327,8 +327,8 @@ endef
 	@-tree -apugsfF $(MAKBET_DOT_DIR)
 
 
-.PHONY: .show-summary-dot-file
-.show-summary-dot-file:
+.PHONY: .show-merged-dot-results
+.show-merged-dot-results:
 	@echo ""
 	@echo "digraph {"
 	@echo ""
@@ -424,7 +424,7 @@ makbet-help: main-help
 	@echo "  .show-dot-dir                  - Show entire content of makbet's internal   "
 	@echo "                                   \"dot\" dir (\$$MAKBET_DOT_DIR).  This     "
 	@echo "                                   target requires MAKBET_DOT=1.              "
-	@echo "  .show-summary-dot-file         - Show the content of results dot file.      "
+	@echo "  .show-merged-dot-results       - Show the merged content of all dot files.  "
 	@echo "                                   This target requires MAKBET_DOT=1.         "
 	@echo "  .show-events-dir               - Show entire content of makbet's internal   "
 	@echo "                                   \"events\" dir (\$$MAKBET_EVENTS_DIR)      "

--- a/tests/resources/expected/examples/01.dummy/__t05__call_makbet-help
+++ b/tests/resources/expected/examples/01.dummy/__t05__call_makbet-help
@@ -37,7 +37,7 @@ All makbet's special targets defined in /home/user/makbet/makbet.mk:
   .show-dot-dir                  - Show entire content of makbet's internal   
                                    "dot" dir ($MAKBET_DOT_DIR).  This     
                                    target requires MAKBET_DOT=1.              
-  .show-summary-dot-file         - Show the content of results dot file.      
+  .show-merged-dot-results       - Show the merged content of all dot files.  
                                    This target requires MAKBET_DOT=1.         
   .show-events-dir               - Show entire content of makbet's internal   
                                    "events" dir ($MAKBET_EVENTS_DIR)      

--- a/tests/src/examples/01.dummy/__t06__call_make_all_and_set_MAKBET_DOT
+++ b/tests/src/examples/01.dummy/__t06__call_make_all_and_set_MAKBET_DOT
@@ -8,7 +8,7 @@ readonly output_file="${1}"
 readonly expected_file="${2}"
 pushd "${MAKBET_PATH}/examples/01.dummy/" > /dev/null
 make makbet-clean && make MAKBET_DOT=1 all
-make .show-summary-dot-file > "${output_file}"
+make .show-merged-dot-results > "${output_file}"
 diff -u -s \
     <( \
         cat "${output_file}" \

--- a/tests/src/examples/01.dummy/__t07__call_make_j8_all_and_set_MAKBET_DOT
+++ b/tests/src/examples/01.dummy/__t07__call_make_j8_all_and_set_MAKBET_DOT
@@ -8,7 +8,7 @@ readonly output_file="${1}"
 readonly expected_file="${2}"
 pushd "${MAKBET_PATH}/examples/01.dummy/" > /dev/null
 make makbet-clean && make -j8 MAKBET_DOT=1 all
-make .show-summary-dot-file > "${output_file}"
+make .show-merged-dot-results > "${output_file}"
 diff -u -s \
     <( \
         cat "${output_file}" \


### PR DESCRIPTION
Rename .show-summary-dot-file task to .show-merged-dot-results as this
new name is more understandable and descriptive.

Resolve #99.
