### PR TITLE
[#100] Rename .show-summary-events-csv-file task

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -285,12 +285,12 @@ easily saved or redirected to file.  This can be achieved by passing
 
   [user@localhost 01.dummy]$
 
-Special **makbet's** target ``.show-summary-events-csv-file`` will display
+Special **makbet's** target ``.show-merged-csv-events`` will display
 **CSV** results which can be used for further processing:
 
 ::
 
-  [user@localhost 01.dummy]$ echo ; make .show-summary-events-csv-file
+  [user@localhost 01.dummy]$ echo ; make .show-merged-csv-events
 
   TASK_ID;TASK_NAME;TASK_DEPS;TASK_CMD;TASK_CMD_OPTS;TASK_EVENT_TYPE;TASK_DATE_TIME_[STARTED|TERMINATED];
   "1";"@01-INIT";"";"";"";"STARTED";"2020-08-31 23:56:00.649587995";

--- a/makbet.mk
+++ b/makbet.mk
@@ -366,8 +366,8 @@ endef
 .show-events-dir: .show-events-cfg-dir .show-events-csv-dir
 
 
-.PHONY: .show-summary-events-csv-file
-.show-summary-events-csv-file:
+.PHONY: .show-merged-csv-events
+.show-merged-csv-events:
 	@find $(MAKBET_EVENTS_CSV_DIR) -name "*.csv" -exec head -1 {} \; | sort -u
 	@find $(MAKBET_EVENTS_CSV_DIR) -name "*.csv" -exec tail -1 {} \; | sort
 	@echo ""
@@ -435,8 +435,8 @@ makbet-help: main-help
 	@echo "  .show-events-csv-dir           - Show entire content of makbet's internal   "
 	@echo "                                   \"events/csv\" (\$$MAKBET_EVENTS_CSV_DIR)  "
 	@echo "                                   dir.  This target requires MAKBET_CSV=1.   "
-	@echo "  .show-summary-events-csv-file  - Show the content of events summary csv     "
-	@echo "                                   file.  This target requires MAKBET_CSV=1.  "
+	@echo "  .show-merged-csv-events        - Show the merged content of all events csv  "
+	@echo "                                   files.  This target requires MAKBET_CSV=1. "
 	@echo "  .show-prof-dir                 - Show entire content of makbet's internal   "
 	@echo "                                   \"prof\" dir (\$$MAKBET_PROF_DIR) including"
 	@echo "                                   all sub-dirs.                              "

--- a/tests/resources/expected/examples/01.dummy/__t05__call_makbet-help
+++ b/tests/resources/expected/examples/01.dummy/__t05__call_makbet-help
@@ -48,8 +48,8 @@ All makbet's special targets defined in /home/user/makbet/makbet.mk:
   .show-events-csv-dir           - Show entire content of makbet's internal   
                                    "events/csv" ($MAKBET_EVENTS_CSV_DIR)  
                                    dir.  This target requires MAKBET_CSV=1.   
-  .show-summary-events-csv-file  - Show the content of events summary csv     
-                                   file.  This target requires MAKBET_CSV=1.  
+  .show-merged-csv-events        - Show the merged content of all events csv  
+                                   files.  This target requires MAKBET_CSV=1. 
   .show-prof-dir                 - Show entire content of makbet's internal   
                                    "prof" dir ($MAKBET_PROF_DIR) including
                                    all sub-dirs.                              

--- a/tests/src/examples/01.dummy/__t08__call_make_all_and_set_MAKBET_CSV
+++ b/tests/src/examples/01.dummy/__t08__call_make_all_and_set_MAKBET_CSV
@@ -8,7 +8,7 @@ readonly output_file="${1}"
 readonly expected_file="${2}"
 pushd "${MAKBET_PATH}/examples/01.dummy/" > /dev/null
 make makbet-clean && make MAKBET_CSV=1 all
-make .show-summary-events-csv-file > "${output_file}"
+make .show-merged-csv-events > "${output_file}"
 diff -u -s \
     <( \
         cat "${output_file}" \

--- a/tests/src/examples/01.dummy/__t09__call_make_j8_all_and_set_MAKBET_CSV
+++ b/tests/src/examples/01.dummy/__t09__call_make_j8_all_and_set_MAKBET_CSV
@@ -8,7 +8,7 @@ readonly output_file="${1}"
 readonly expected_file="${2}"
 pushd "${MAKBET_PATH}/examples/01.dummy/" > /dev/null
 make makbet-clean && make -j8 MAKBET_CSV=1 all
-make .show-summary-events-csv-file > "${output_file}"
+make .show-merged-csv-events > "${output_file}"
 diff -u -s \
     <( \
         cat "${output_file}" \


### PR DESCRIPTION
Change the name of .show-summary-events-csv-file task to something
shorter and more convinient: .show-merged-csv-events.

Resolve #100.
