### PR TITLE
[#114] Fix "/bin/sh: 1: 0: not found" error

### DIFF
--- a/makbet.mk
+++ b/makbet.mk
@@ -10,6 +10,10 @@
 ifndef MAKBET_PATH
   $(error MAKBET_PATH is not defined)
 else
+
+  # Set the SHELL variable as soon as MAKBET_PATH is defined.
+  SHELL=/bin/bash
+
   MAKBET_CACHE_DIR := $(MAKBET_PATH)/.cache
   MAKBET_CORE_DIR := $(MAKBET_PATH)/core
   MAKBET_SCENARIO_PATH := $(realpath $(firstword $(MAKEFILE_LIST)))


### PR DESCRIPTION
This problem has been noticed on Ubuntu 20.04.1 LTS.
It looks that /bin/sh is a symlink to dash (see below) while bash
interpreter is expected:

lrwxrwxrwx 1 root root 4 paź 12 20:35 /bin/sh -> dash

Use SHELL=/bin/bash explicitly in makbet.mk to indicate that bash
will be used as a shell interpreter.  It is of course expected that
/bin/bash exists in the system (so far there is no additional test to
check it).

Resolve #114.
