### PR TITLE
[#133] Correct examples/README.rst file

### DIFF
--- a/examples/README.rst
+++ b/examples/README.rst
@@ -136,13 +136,12 @@ The **makbet's** examples directory structure is:
   │   └── Makefile
   ├── lib/
   │   └── tasks/
-  │       ├── 02.toolchain/
-  │       │   └── common/
-  │       │       ├── build-doxygen.sh
-  │       │       ├── build-git.sh
-  │       │       ├── build-kcov.sh
-  │       │       ├── build-make.sh
-  │       │       └── build-python.sh
+  │       ├── build-scripts/
+  │       │   ├── build-doxygen.sh
+  │       │   ├── build-git.sh
+  │       │   ├── build-kcov.sh
+  │       │   ├── build-make.sh
+  │       │   └── build-python.sh
   │       └── common/
   │           ├── check-dirs.sh
   │           ├── check-files.sh


### PR DESCRIPTION
Add missing lib/tasks/build-scripts/ directory to section called
"Directory structure".

Resolve #133.
