### PR TITLE
[#152] Rename .cache directory to .makbet-cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Ignore makbet's cache directory.
-.cache/
+.makbet-cache/
 
 # Ignore the top-level Visual Studio Code directory.
 .vscode/

--- a/README.rst
+++ b/README.rst
@@ -472,8 +472,8 @@ execution command (by default ``MAKBET_PROF=0``) as in example below:
 
 When ``MAKBET_PROF=1`` is passed to the ``make`` command then **makbet** will
 save some additional **cfg** files during the runtime.  All these files will
-be saved in ``.cache/prof/cfg/`` directory and they can be seen by invoking
-one of **makbet's** special targets: ``.show-prof-dir`` or
+be saved in ``.makbet-cache/prof/cfg/`` directory and they can be seen by
+invoking one of **makbet's** special targets: ``.show-prof-dir`` or
 ``.show-prof-cfg-dir``.
 
 For example:
@@ -481,22 +481,22 @@ For example:
 ::
 
   [user@localhost 01.dummy]$ make .show-prof-dir
-  /home/user/makbet/.cache/prof/cfg
-  ├── [-rw-r--r-- user user         220]  /home/user/makbet/.cache/prof/cfg/@01-INIT.cfg
-  ├── [-rw-r--r-- user user         222]  /home/user/makbet/.cache/prof/cfg/all.cfg
-  ├── [-rw-r--r-- user user         304]  /home/user/makbet/.cache/prof/cfg/task-A.cfg
-  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.cache/prof/cfg/task-B1.cfg
-  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.cache/prof/cfg/task-B2.cfg
-  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.cache/prof/cfg/task-B3.cfg
-  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.cache/prof/cfg/task-B4.cfg
-  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.cache/prof/cfg/task-B5.cfg
-  ├── [-rw-r--r-- user user         311]  /home/user/makbet/.cache/prof/cfg/task-C.cfg
-  ├── [-rw-r--r-- user user         302]  /home/user/makbet/.cache/prof/cfg/task-D.cfg
-  ├── [-rw-r--r-- user user         327]  /home/user/makbet/.cache/prof/cfg/task-E.cfg
-  └── [-rw-r--r-- user user         225]  /home/user/makbet/.cache/prof/cfg/task-F.cfg
+  /home/user/makbet/.makbet-cache/prof/cfg
+  ├── [-rw-r--r-- user user         220]  /home/user/makbet/.makbet-cache/prof/cfg/@01-INIT.cfg
+  ├── [-rw-r--r-- user user         222]  /home/user/makbet/.makbet-cache/prof/cfg/all.cfg
+  ├── [-rw-r--r-- user user         304]  /home/user/makbet/.makbet-cache/prof/cfg/task-A.cfg
+  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.makbet-cache/prof/cfg/task-B1.cfg
+  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.makbet-cache/prof/cfg/task-B2.cfg
+  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.makbet-cache/prof/cfg/task-B3.cfg
+  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.makbet-cache/prof/cfg/task-B4.cfg
+  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.makbet-cache/prof/cfg/task-B5.cfg
+  ├── [-rw-r--r-- user user         311]  /home/user/makbet/.makbet-cache/prof/cfg/task-C.cfg
+  ├── [-rw-r--r-- user user         302]  /home/user/makbet/.makbet-cache/prof/cfg/task-D.cfg
+  ├── [-rw-r--r-- user user         327]  /home/user/makbet/.makbet-cache/prof/cfg/task-E.cfg
+  └── [-rw-r--r-- user user         225]  /home/user/makbet/.makbet-cache/prof/cfg/task-F.cfg
 
   0 directories, 12 files
-  /home/user/makbet/.cache/prof/csv
+  /home/user/makbet/.makbet-cache/prof/csv
 
   0 directories, 0 files
   [user@localhost 01.dummy]$
@@ -506,7 +506,7 @@ An example content of **cfg** profiling file (generated for task ``all`` from
 
 ::
 
-  [user@localhost 01.dummy]$ echo ; cat /home/user/makbet/.cache/prof/cfg/all.cfg ; echo
+  [user@localhost 01.dummy]$ echo ; cat /home/user/makbet/.makbet-cache/prof/cfg/all.cfg ; echo
 
   TASK_ID="13"
   TASK_NAME="all"
@@ -575,69 +575,70 @@ For example:
   T2 - T1 = 00h:00m:00s.020ms
   [user@localhost 01.dummy]$
 
-When both ``MAKBET_PROF=1`` and ``MAKBET_CSV=1`` options are passed to the
-``make`` command then **makbet** will save **a pair of additional files**
-for each target run during the runtime.  As already mentioned above the
-``MAKBET_PROF=1`` option will produce **cfg** files inside ``.cache/prof/cfg/``
-directory.  Using ``MAKBET_CSV=1`` option will generate extra **csv** files
-inside corresponding ``.cache/prof/csv/`` directory.  The whole ``.cache/prof/``
-directory content can be shown by invoking **makbet's** special target
-``.show-prof-dir`` as in example below:
+When both ``MAKBET_PROF=1`` and ``MAKBET_CSV=1`` options are passed
+to the ``make`` command then **makbet** will save **a pair of additional
+files** for each target run during the runtime.  As already mentioned
+above the ``MAKBET_PROF=1`` option will produce **cfg** files inside
+``.makbet-cache/prof/cfg/`` directory.  Using ``MAKBET_CSV=1`` option
+will generate extra **csv** files inside corresponding
+``.makbet-cache/prof/csv/`` directory.  The whole
+``.makbet-cache/prof/`` directory content can be shown by invoking
+**makbet's** special target ``.show-prof-dir`` as in example below:
 
 ::
 
   [user@localhost 01.dummy]$ make .show-prof-dir
-  /home/user/makbet/.cache/prof/cfg
-  ├── [-rw-r--r-- user user         220]  /home/user/makbet/.cache/prof/cfg/@01-INIT.cfg
-  ├── [-rw-r--r-- user user         222]  /home/user/makbet/.cache/prof/cfg/all.cfg
-  ├── [-rw-r--r-- user user         304]  /home/user/makbet/.cache/prof/cfg/task-A.cfg
-  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.cache/prof/cfg/task-B1.cfg
-  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.cache/prof/cfg/task-B2.cfg
-  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.cache/prof/cfg/task-B3.cfg
-  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.cache/prof/cfg/task-B4.cfg
-  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.cache/prof/cfg/task-B5.cfg
-  ├── [-rw-r--r-- user user         311]  /home/user/makbet/.cache/prof/cfg/task-C.cfg
-  ├── [-rw-r--r-- user user         302]  /home/user/makbet/.cache/prof/cfg/task-D.cfg
-  ├── [-rw-r--r-- user user         327]  /home/user/makbet/.cache/prof/cfg/task-E.cfg
-  └── [-rw-r--r-- user user         225]  /home/user/makbet/.cache/prof/cfg/task-F.cfg
+  /home/user/makbet/.makbet-cache/prof/cfg
+  ├── [-rw-r--r-- user user         220]  /home/user/makbet/.makbet-cache/prof/cfg/@01-INIT.cfg
+  ├── [-rw-r--r-- user user         222]  /home/user/makbet/.makbet-cache/prof/cfg/all.cfg
+  ├── [-rw-r--r-- user user         304]  /home/user/makbet/.makbet-cache/prof/cfg/task-A.cfg
+  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.makbet-cache/prof/cfg/task-B1.cfg
+  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.makbet-cache/prof/cfg/task-B2.cfg
+  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.makbet-cache/prof/cfg/task-B3.cfg
+  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.makbet-cache/prof/cfg/task-B4.cfg
+  ├── [-rw-r--r-- user user         303]  /home/user/makbet/.makbet-cache/prof/cfg/task-B5.cfg
+  ├── [-rw-r--r-- user user         311]  /home/user/makbet/.makbet-cache/prof/cfg/task-C.cfg
+  ├── [-rw-r--r-- user user         302]  /home/user/makbet/.makbet-cache/prof/cfg/task-D.cfg
+  ├── [-rw-r--r-- user user         327]  /home/user/makbet/.makbet-cache/prof/cfg/task-E.cfg
+  └── [-rw-r--r-- user user         225]  /home/user/makbet/.makbet-cache/prof/cfg/task-F.cfg
 
   0 directories, 12 files
-  /home/user/makbet/.cache/prof/csv
-  ├── [-rw-r--r-- user user         222]  /home/user/makbet/.cache/prof/csv/@01-INIT.csv
-  ├── [-rw-r--r-- user user         224]  /home/user/makbet/.cache/prof/csv/all.csv
-  ├── [-rw-r--r-- user user         306]  /home/user/makbet/.cache/prof/csv/task-A.csv
-  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.cache/prof/csv/task-B1.csv
-  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.cache/prof/csv/task-B2.csv
-  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.cache/prof/csv/task-B3.csv
-  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.cache/prof/csv/task-B4.csv
-  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.cache/prof/csv/task-B5.csv
-  ├── [-rw-r--r-- user user         313]  /home/user/makbet/.cache/prof/csv/task-C.csv
-  ├── [-rw-r--r-- user user         304]  /home/user/makbet/.cache/prof/csv/task-D.csv
-  ├── [-rw-r--r-- user user         329]  /home/user/makbet/.cache/prof/csv/task-E.csv
-  └── [-rw-r--r-- user user         227]  /home/user/makbet/.cache/prof/csv/task-F.csv
+  /home/user/makbet/.makbet-cache/prof/csv
+  ├── [-rw-r--r-- user user         222]  /home/user/makbet/.makbet-cache/prof/csv/@01-INIT.csv
+  ├── [-rw-r--r-- user user         224]  /home/user/makbet/.makbet-cache/prof/csv/all.csv
+  ├── [-rw-r--r-- user user         306]  /home/user/makbet/.makbet-cache/prof/csv/task-A.csv
+  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.makbet-cache/prof/csv/task-B1.csv
+  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.makbet-cache/prof/csv/task-B2.csv
+  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.makbet-cache/prof/csv/task-B3.csv
+  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.makbet-cache/prof/csv/task-B4.csv
+  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.makbet-cache/prof/csv/task-B5.csv
+  ├── [-rw-r--r-- user user         313]  /home/user/makbet/.makbet-cache/prof/csv/task-C.csv
+  ├── [-rw-r--r-- user user         304]  /home/user/makbet/.makbet-cache/prof/csv/task-D.csv
+  ├── [-rw-r--r-- user user         329]  /home/user/makbet/.makbet-cache/prof/csv/task-E.csv
+  └── [-rw-r--r-- user user         227]  /home/user/makbet/.makbet-cache/prof/csv/task-F.csv
 
   0 directories, 12 files
   [user@localhost 01.dummy]$
 
-For showing the content of ``.cache/prof/csv/`` directory only, dedicated
-special target ``.show-prof-csv-dir`` can be used:
+For showing the content of ``.makbet-cache/prof/csv/`` directory only,
+dedicated special target ``.show-prof-csv-dir`` can be used:
 
 ::
 
   [user@localhost 01.dummy]$ make .show-prof-csv-dir
-  /home/user/.cache/prof/csv
-  ├── [-rw-r--r-- user user         222]  /home/user/makbet/.cache/prof/csv/@01-INIT.csv
-  ├── [-rw-r--r-- user user         224]  /home/user/makbet/.cache/prof/csv/all.csv
-  ├── [-rw-r--r-- user user         306]  /home/user/makbet/.cache/prof/csv/task-A.csv
-  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.cache/prof/csv/task-B1.csv
-  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.cache/prof/csv/task-B2.csv
-  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.cache/prof/csv/task-B3.csv
-  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.cache/prof/csv/task-B4.csv
-  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.cache/prof/csv/task-B5.csv
-  ├── [-rw-r--r-- user user         313]  /home/user/makbet/.cache/prof/csv/task-C.csv
-  ├── [-rw-r--r-- user user         304]  /home/user/makbet/.cache/prof/csv/task-D.csv
-  ├── [-rw-r--r-- user user         329]  /home/user/makbet/.cache/prof/csv/task-E.csv
-  └── [-rw-r--r-- user user         227]  /home/user/makbet/.cache/prof/csv/task-F.csv
+  /home/user/.makbet-cache/prof/csv
+  ├── [-rw-r--r-- user user         222]  /home/user/makbet/.makbet-cache/prof/csv/@01-INIT.csv
+  ├── [-rw-r--r-- user user         224]  /home/user/makbet/.makbet-cache/prof/csv/all.csv
+  ├── [-rw-r--r-- user user         306]  /home/user/makbet/.makbet-cache/prof/csv/task-A.csv
+  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.makbet-cache/prof/csv/task-B1.csv
+  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.makbet-cache/prof/csv/task-B2.csv
+  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.makbet-cache/prof/csv/task-B3.csv
+  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.makbet-cache/prof/csv/task-B4.csv
+  ├── [-rw-r--r-- user user         305]  /home/user/makbet/.makbet-cache/prof/csv/task-B5.csv
+  ├── [-rw-r--r-- user user         313]  /home/user/makbet/.makbet-cache/prof/csv/task-C.csv
+  ├── [-rw-r--r-- user user         304]  /home/user/makbet/.makbet-cache/prof/csv/task-D.csv
+  ├── [-rw-r--r-- user user         329]  /home/user/makbet/.makbet-cache/prof/csv/task-E.csv
+  └── [-rw-r--r-- user user         227]  /home/user/makbet/.makbet-cache/prof/csv/task-F.csv
 
   0 directories, 12 files
   [user@localhost 01.dummy]$
@@ -647,7 +648,7 @@ An example content of **csv** profiling file (generated for task ``all`` from
 
 ::
 
-  [user@localhost 01.dummy]$ echo ; cat /home/user/makbet/.cache/prof/csv/all.csv ; echo
+  [user@localhost 01.dummy]$ echo ; cat /home/user/makbet/.makbet-cache/prof/csv/all.csv ; echo
 
   TASK_ID;TASK_NAME;TASK_DEPS;TASK_CMD;TASK_CMD_OPTS;TASK_DATE_TIME_STARTED;TASK_DATE_TIME_TERMINATED;TASK_DURATION;
   "13";"all";"task-F";"";"";"2020-10-10 19:53:35.123305878";"2020-10-10 19:53:35.143659530";00h:00m:00s.020ms;

--- a/core/README.rst
+++ b/core/README.rst
@@ -72,26 +72,27 @@ where:
 
 - ``__save_dot_file`` - This script will save the **DOT** code, describing
   every task, to its dedicated file (file with ``*.dot`` extension) inside
-  the ``$MAKBET_PATH/.cache/dot/`` directory.  The script is being run only
-  when ``MAKBET_DOT`` variable is set to ``1``.  By default ``MAKBET_DOT=0``.
+  the ``$MAKBET_PATH/.makbet-cache/dot/`` directory.  The script is being
+  run only when ``MAKBET_DOT`` variable is set to ``1``.  By default
+  ``MAKBET_DOT=0``.
 
 - ``__save_task_event`` - This script will save task's ``*.cfg`` event file
-  into ``$MAKBET_PATH/.cache/events/cfg/`` directory.  Every task event file
-  can be converted from ``*.cfg`` to ``*.csv`` form when ``MAKBET_CSV``
+  into ``$MAKBET_PATH/.makbet-cache/events/cfg/`` directory.  Every task event
+  file can be converted from ``*.cfg`` to ``*.csv`` form when ``MAKBET_CSV``
   variable is set to ``1``.  By default ``MAKBET_CSV=0``.  In case
   ``MAKBET_CSV=1`` the script ``__convert_cfg2csv``, described above, will
   convert ``*.cfg`` file to ``*.csv`` form, and save it into
-  ``$MAKBET_PATH/.cache/events/csv/`` location.  The ``MAKBET_CSV_SEP`` and
-  ``MAKBET_EVENTS_CSV_HEADER`` variables defined in ``makbet.mk`` file will
-  be used during ``*.csv`` file generation.
+  ``$MAKBET_PATH/.makbet-cache/events/csv/`` location.  The ``MAKBET_CSV_SEP``
+  and ``MAKBET_EVENTS_CSV_HEADER`` variables defined in ``makbet.mk`` file
+  will be used during ``*.csv`` file generation.
 
 - ``__save_task_profile`` - This script will save task's ``*.cfg`` **profile**
-  **results** - inside ``$MAKBET_PATH/.cache/prof/cfg/`` directory.  Tasks
-  profiling is disabled by default (``MAKBET_PROF=0``).  In case
+  **results** - inside ``$MAKBET_PATH/.makbet-cache/prof/cfg/`` directory.
+  Tasks profiling is disabled by default (``MAKBET_PROF=0``).  In case
   ``MAKBET_CSV=1`` the script ``__convert_cfg2csv``, described above, will
   convert ``*.cfg`` file to ``*.csv`` form, and save it into
-  ``$MAKBET_PATH/.cache/prof/csv/`` location.  The ``MAKBET_CSV_SEP`` and
-  ``MAKBET_PROF_CSV_HEADER`` variables defined in ``makbet.mk`` file will
+  ``$MAKBET_PATH/.makbet-cache/prof/csv/`` location.  The ``MAKBET_CSV_SEP``
+  and ``MAKBET_PROF_CSV_HEADER`` variables defined in ``makbet.mk`` file will
   be used during ``*.csv`` file generation.
 
 - ``README.rst`` - The file you are reading now.

--- a/makbet.mk
+++ b/makbet.mk
@@ -33,7 +33,7 @@ else
   # Set MAKBET_CACHE_DIR, MAKBET_CORE_DIR and MAKBET_SCENARIO_PATH
   # variables as soon as MAKBET_PATH is defined.
   #
-  MAKBET_CACHE_DIR := $(MAKBET_PATH)/.cache
+  MAKBET_CACHE_DIR := $(MAKBET_PATH)/.makbet-cache
   MAKBET_CORE_DIR := $(MAKBET_PATH)/core
   MAKBET_SCENARIO_PATH := $(realpath $(firstword $(MAKEFILE_LIST)))
 endif
@@ -154,7 +154,7 @@ endif
 # Create makbet's internals dir structure as fast as possible.
 #
 # $MAKBET_PATH/
-# └── .cache/
+# └── .makbet-cache/
 #     ├── dot/
 #     ├── events/
 #     │   ├── cfg/
@@ -266,7 +266,7 @@ $(MAKBET_EVENTS_CFG_DIR)/$(strip $(1)).terminated.cfg: $(foreach d,$(3),$(MAKBET
 		"$(MAKBET_EVENTS_CFG_DIR)/$(strip $(1)).terminated.cfg" \
 		"TERMINATED"
 	@#
-	@# Save *.dot file in .cache/dot/ dir if MAKBET_DOT=1.
+	@# Save *.dot file in .makbet-cache/dot/ dir if MAKBET_DOT=1.
 	$(_q)if (( $(MAKBET_DOT) == 1 )) ; \
 	then \
 		$(MAKBET_CORE_DIR)/__save_dot_file \
@@ -449,33 +449,33 @@ makbet-help: main-help
 	@echo
 	@echo "All makbet's special targets defined in $(MAKBET_PATH)/makbet.mk:             "
 	@echo
-	@echo "    .show-cache-dir              - Show entire content of makbet's internal   "
-	@echo "                                   \".cache/\" dir.                           "
-	@echo "    .show-dot-dir                - Show entire content of makbet's internal   "
-	@echo "                                   \".cache/dot/\" dir (this target requires  "
-	@echo "                                   prior MAKBET_DOT=1 usage).                 "
+	@echo "    .show-cache-dir              - Show entire content of internal            "
+	@echo "                                   \".makbet-cache/\" dir.                    "
+	@echo "    .show-dot-dir                - Show entire content of internal            "
+	@echo "                                   \".makbet-cache/dot/\" dir (this target    "
+	@echo "                                   requires prior MAKBET_DOT=1 usage).        "
 	@echo "    .show-merged-dot-results     - Show merged content of all dot files (this "
 	@echo "                                   target requires prior MAKBET_DOT=1 usage). "
-	@echo "    .show-events-dir             - Show entire content of makbet's internal   "
-	@echo "                                   \".cache/events/\" dir including all       "
-	@echo "                                   sub-dirs.                                  "
-	@echo "    .show-events-cfg-dir         - Show entire content of makbet's internal   "
-	@echo "                                   \".cache/events/cfg/\" dir.                "
-	@echo "    .show-events-csv-dir         - Show entire content of makbet's internal   "
-	@echo "                                   \".cache/events/csv/\" dir (this target    "
-	@echo "                                   requires prior MAKBET_CSV=1 usage).        "
+	@echo "    .show-events-dir             - Show entire content of internal            "
+	@echo "                                   \".makbet-cache/events/\" dir including    "
+	@echo "                                   all its sub-dirs.                          "
+	@echo "    .show-events-cfg-dir         - Show entire content of internal            "
+	@echo "                                   \".makbet-cache/events/cfg/\" dir.         "
+	@echo "    .show-events-csv-dir         - Show entire content of internal            "
+	@echo "                                   \".makbet-cache/events/csv/\" dir (this    "
+	@echo "                                   target requires prior MAKBET_CSV=1 usage). "
 	@echo "    .show-merged-csv-events      - Show merged content of all event csv files "
 	@echo "                                   (this target requires prior MAKBET_CSV=1   "
 	@echo "                                   usage).                                    "
-	@echo "    .show-prof-dir               - Show entire content of makbet's internal   "
-	@echo "                                   \".cache/prof/\" dir including all         "
-	@echo "                                   sub-dirs.                                  "
-	@echo "    .show-prof-cfg-dir           - Show entire content of makbet's internal   "
-	@echo "                                   \".cache/prof/cfg/\" dir (this target      "
-	@echo "                                   requires prior MAKBET_PROF=1 usage).       "
-	@echo "    .show-prof-csv-dir           - Show entire content of makbet's internal   "
-	@echo "                                   \".cache/prof/csv/\" dir (this target      "
-	@echo "                                   requires prior MAKBET_PROF=1 and           "
+	@echo "    .show-prof-dir               - Show entire content of internal            "
+	@echo "                                   \".makbet-cache/prof/\" dir including all  "
+	@echo "                                   its sub-dirs.                              "
+	@echo "    .show-prof-cfg-dir           - Show entire content of internal            "
+	@echo "                                   \".makbet-cache/prof/cfg/\" dir (this      "
+	@echo "                                   target requires prior MAKBET_PROF=1 usage)."
+	@echo "    .show-prof-csv-dir           - Show entire content of internal            "
+	@echo "                                   \".makbet-cache/prof/csv/\" dir (this      "
+	@echo "                                   target requires prior MAKBET_PROF=1 and    "
 	@echo "                                   MAKBET_CSV=1 usage).                       "
 	@echo "    .show-merged-csv-profiles    - Show merged content of all profile csv     "
 	@echo "                                   files (this target requires prior          "
@@ -545,8 +545,7 @@ main-help: makbet-version
 	@echo "                                   target \"help\" above) then append extended"
 	@echo "                                   help message containing the list of all    "
 	@echo "                                   special makbet's targets.                  "
-	@echo "    makbet-clean                 - Clean entire makbet's internal \".cache/\" "
-	@echo "                                   dir.                                       "
+	@echo "    makbet-clean                 - Clean entire \".makbet-cache/\" dir.       "
 	@echo "    makbet-version               - Print makbet's version only.               "
 	@echo
 	@echo "Examples:                                                                     "

--- a/tests/resources/expected/examples/01.dummy/t01__make
+++ b/tests/resources/expected/examples/01.dummy/t01__make
@@ -18,8 +18,7 @@ All makbet's basic targets defined in /home/user/makbet//makbet.mk:
                                    target "help" above) then append extended
                                    help message containing the list of all    
                                    special makbet's targets.                  
-    makbet-clean                 - Clean entire makbet's internal ".cache/" 
-                                   dir.                                       
+    makbet-clean                 - Clean entire ".makbet-cache/" dir.       
     makbet-version               - Print makbet's version only.               
 
 Examples:                                                                     

--- a/tests/resources/expected/examples/01.dummy/t05__make,-f,Makefile,makbet-help
+++ b/tests/resources/expected/examples/01.dummy/t05__make,-f,Makefile,makbet-help
@@ -18,8 +18,7 @@ All makbet's basic targets defined in /home/user/makbet/makbet.mk:
                                    target "help" above) then append extended
                                    help message containing the list of all    
                                    special makbet's targets.                  
-    makbet-clean                 - Clean entire makbet's internal ".cache/" 
-                                   dir.                                       
+    makbet-clean                 - Clean entire ".makbet-cache/" dir.       
     makbet-version               - Print makbet's version only.               
 
 Examples:                                                                     
@@ -33,33 +32,33 @@ Examples:
 
 All makbet's special targets defined in /home/user/makbet/makbet.mk:             
 
-    .show-cache-dir              - Show entire content of makbet's internal   
-                                   ".cache/" dir.                           
-    .show-dot-dir                - Show entire content of makbet's internal   
-                                   ".cache/dot/" dir (this target requires  
-                                   prior MAKBET_DOT=1 usage).                 
+    .show-cache-dir              - Show entire content of internal            
+                                   ".makbet-cache/" dir.                    
+    .show-dot-dir                - Show entire content of internal            
+                                   ".makbet-cache/dot/" dir (this target    
+                                   requires prior MAKBET_DOT=1 usage).        
     .show-merged-dot-results     - Show merged content of all dot files (this 
                                    target requires prior MAKBET_DOT=1 usage). 
-    .show-events-dir             - Show entire content of makbet's internal   
-                                   ".cache/events/" dir including all       
-                                   sub-dirs.                                  
-    .show-events-cfg-dir         - Show entire content of makbet's internal   
-                                   ".cache/events/cfg/" dir.                
-    .show-events-csv-dir         - Show entire content of makbet's internal   
-                                   ".cache/events/csv/" dir (this target    
-                                   requires prior MAKBET_CSV=1 usage).        
+    .show-events-dir             - Show entire content of internal            
+                                   ".makbet-cache/events/" dir including    
+                                   all its sub-dirs.                          
+    .show-events-cfg-dir         - Show entire content of internal            
+                                   ".makbet-cache/events/cfg/" dir.         
+    .show-events-csv-dir         - Show entire content of internal            
+                                   ".makbet-cache/events/csv/" dir (this    
+                                   target requires prior MAKBET_CSV=1 usage). 
     .show-merged-csv-events      - Show merged content of all event csv files 
                                    (this target requires prior MAKBET_CSV=1   
                                    usage).                                    
-    .show-prof-dir               - Show entire content of makbet's internal   
-                                   ".cache/prof/" dir including all         
-                                   sub-dirs.                                  
-    .show-prof-cfg-dir           - Show entire content of makbet's internal   
-                                   ".cache/prof/cfg/" dir (this target      
-                                   requires prior MAKBET_PROF=1 usage).       
-    .show-prof-csv-dir           - Show entire content of makbet's internal   
-                                   ".cache/prof/csv/" dir (this target      
-                                   requires prior MAKBET_PROF=1 and           
+    .show-prof-dir               - Show entire content of internal            
+                                   ".makbet-cache/prof/" dir including all  
+                                   its sub-dirs.                              
+    .show-prof-cfg-dir           - Show entire content of internal            
+                                   ".makbet-cache/prof/cfg/" dir (this      
+                                   target requires prior MAKBET_PROF=1 usage).
+    .show-prof-csv-dir           - Show entire content of internal            
+                                   ".makbet-cache/prof/csv/" dir (this      
+                                   target requires prior MAKBET_PROF=1 and    
                                    MAKBET_CSV=1 usage).                       
     .show-merged-csv-profiles    - Show merged content of all profile csv     
                                    files (this target requires prior          

--- a/tests/resources/expected/examples/01.dummy/t10__make,MAKBET_DOT=1,all
+++ b/tests/resources/expected/examples/01.dummy/t10__make,MAKBET_DOT=1,all
@@ -1,4 +1,4 @@
-.cache/
+.makbet-cache/
 ├── dot/
 │   ├── @01-INIT.dot
 │   ├── all.dot

--- a/tests/resources/expected/examples/01.dummy/t11__make,MAKBET_CSV=1,all
+++ b/tests/resources/expected/examples/01.dummy/t11__make,MAKBET_CSV=1,all
@@ -1,4 +1,4 @@
-.cache/
+.makbet-cache/
 ├── dot/
 ├── events/
 │   ├── cfg/

--- a/tests/resources/expected/examples/01.dummy/t12__make,MAKBET_CSV=1,MAKBET_DOT=1,all
+++ b/tests/resources/expected/examples/01.dummy/t12__make,MAKBET_CSV=1,MAKBET_DOT=1,all
@@ -1,4 +1,4 @@
-.cache/
+.makbet-cache/
 ├── dot/
 │   ├── @01-INIT.dot
 │   ├── all.dot

--- a/tests/resources/expected/examples/02.toolchain-simple/t01__make
+++ b/tests/resources/expected/examples/02.toolchain-simple/t01__make
@@ -18,8 +18,7 @@ All makbet's basic targets defined in /home/user/makbet/makbet.mk:
                                    target "help" above) then append extended
                                    help message containing the list of all    
                                    special makbet's targets.                  
-    makbet-clean                 - Clean entire makbet's internal ".cache/" 
-                                   dir.                                       
+    makbet-clean                 - Clean entire ".makbet-cache/" dir.       
     makbet-version               - Print makbet's version only.               
 
 Examples:                                                                     

--- a/tests/resources/expected/examples/02.toolchain-simple/t07__make,makbet-help
+++ b/tests/resources/expected/examples/02.toolchain-simple/t07__make,makbet-help
@@ -18,8 +18,7 @@ All makbet's basic targets defined in /home/user/makbet/makbet.mk:
                                    target "help" above) then append extended
                                    help message containing the list of all    
                                    special makbet's targets.                  
-    makbet-clean                 - Clean entire makbet's internal ".cache/" 
-                                   dir.                                       
+    makbet-clean                 - Clean entire ".makbet-cache/" dir.       
     makbet-version               - Print makbet's version only.               
 
 Examples:                                                                     
@@ -33,33 +32,33 @@ Examples:
 
 All makbet's special targets defined in /home/user/makbet/makbet.mk:             
 
-    .show-cache-dir              - Show entire content of makbet's internal   
-                                   ".cache/" dir.                           
-    .show-dot-dir                - Show entire content of makbet's internal   
-                                   ".cache/dot/" dir (this target requires  
-                                   prior MAKBET_DOT=1 usage).                 
+    .show-cache-dir              - Show entire content of internal            
+                                   ".makbet-cache/" dir.                    
+    .show-dot-dir                - Show entire content of internal            
+                                   ".makbet-cache/dot/" dir (this target    
+                                   requires prior MAKBET_DOT=1 usage).        
     .show-merged-dot-results     - Show merged content of all dot files (this 
                                    target requires prior MAKBET_DOT=1 usage). 
-    .show-events-dir             - Show entire content of makbet's internal   
-                                   ".cache/events/" dir including all       
-                                   sub-dirs.                                  
-    .show-events-cfg-dir         - Show entire content of makbet's internal   
-                                   ".cache/events/cfg/" dir.                
-    .show-events-csv-dir         - Show entire content of makbet's internal   
-                                   ".cache/events/csv/" dir (this target    
-                                   requires prior MAKBET_CSV=1 usage).        
+    .show-events-dir             - Show entire content of internal            
+                                   ".makbet-cache/events/" dir including    
+                                   all its sub-dirs.                          
+    .show-events-cfg-dir         - Show entire content of internal            
+                                   ".makbet-cache/events/cfg/" dir.         
+    .show-events-csv-dir         - Show entire content of internal            
+                                   ".makbet-cache/events/csv/" dir (this    
+                                   target requires prior MAKBET_CSV=1 usage). 
     .show-merged-csv-events      - Show merged content of all event csv files 
                                    (this target requires prior MAKBET_CSV=1   
                                    usage).                                    
-    .show-prof-dir               - Show entire content of makbet's internal   
-                                   ".cache/prof/" dir including all         
-                                   sub-dirs.                                  
-    .show-prof-cfg-dir           - Show entire content of makbet's internal   
-                                   ".cache/prof/cfg/" dir (this target      
-                                   requires prior MAKBET_PROF=1 usage).       
-    .show-prof-csv-dir           - Show entire content of makbet's internal   
-                                   ".cache/prof/csv/" dir (this target      
-                                   requires prior MAKBET_PROF=1 and           
+    .show-prof-dir               - Show entire content of internal            
+                                   ".makbet-cache/prof/" dir including all  
+                                   its sub-dirs.                              
+    .show-prof-cfg-dir           - Show entire content of internal            
+                                   ".makbet-cache/prof/cfg/" dir (this      
+                                   target requires prior MAKBET_PROF=1 usage).
+    .show-prof-csv-dir           - Show entire content of internal            
+                                   ".makbet-cache/prof/csv/" dir (this      
+                                   target requires prior MAKBET_PROF=1 and    
                                    MAKBET_CSV=1 usage).                       
     .show-merged-csv-profiles    - Show merged content of all profile csv     
                                    files (this target requires prior          

--- a/tests/resources/expected/examples/03.toolchain-advanced/t01__make
+++ b/tests/resources/expected/examples/03.toolchain-advanced/t01__make
@@ -18,8 +18,7 @@ All makbet's basic targets defined in /home/user/makbet/makbet.mk:
                                    target "help" above) then append extended
                                    help message containing the list of all    
                                    special makbet's targets.                  
-    makbet-clean                 - Clean entire makbet's internal ".cache/" 
-                                   dir.                                       
+    makbet-clean                 - Clean entire ".makbet-cache/" dir.       
     makbet-version               - Print makbet's version only.               
 
 Examples:                                                                     

--- a/tests/resources/expected/examples/04.ping-dns-servers/t01__make
+++ b/tests/resources/expected/examples/04.ping-dns-servers/t01__make
@@ -18,8 +18,7 @@ All makbet's basic targets defined in /home/user/makbet//makbet.mk:
                                    target "help" above) then append extended
                                    help message containing the list of all    
                                    special makbet's targets.                  
-    makbet-clean                 - Clean entire makbet's internal ".cache/" 
-                                   dir.                                       
+    makbet-clean                 - Clean entire ".makbet-cache/" dir.       
     makbet-version               - Print makbet's version only.               
 
 Examples:                                                                     

--- a/tests/resources/expected/examples/04.ping-dns-servers/t04__make,makbet-help
+++ b/tests/resources/expected/examples/04.ping-dns-servers/t04__make,makbet-help
@@ -18,8 +18,7 @@ All makbet's basic targets defined in /home/user/makbet//makbet.mk:
                                    target "help" above) then append extended
                                    help message containing the list of all    
                                    special makbet's targets.                  
-    makbet-clean                 - Clean entire makbet's internal ".cache/" 
-                                   dir.                                       
+    makbet-clean                 - Clean entire ".makbet-cache/" dir.       
     makbet-version               - Print makbet's version only.               
 
 Examples:                                                                     
@@ -33,33 +32,33 @@ Examples:
 
 All makbet's special targets defined in /home/user/makbet//makbet.mk:             
 
-    .show-cache-dir              - Show entire content of makbet's internal   
-                                   ".cache/" dir.                           
-    .show-dot-dir                - Show entire content of makbet's internal   
-                                   ".cache/dot/" dir (this target requires  
-                                   prior MAKBET_DOT=1 usage).                 
+    .show-cache-dir              - Show entire content of internal            
+                                   ".makbet-cache/" dir.                    
+    .show-dot-dir                - Show entire content of internal            
+                                   ".makbet-cache/dot/" dir (this target    
+                                   requires prior MAKBET_DOT=1 usage).        
     .show-merged-dot-results     - Show merged content of all dot files (this 
                                    target requires prior MAKBET_DOT=1 usage). 
-    .show-events-dir             - Show entire content of makbet's internal   
-                                   ".cache/events/" dir including all       
-                                   sub-dirs.                                  
-    .show-events-cfg-dir         - Show entire content of makbet's internal   
-                                   ".cache/events/cfg/" dir.                
-    .show-events-csv-dir         - Show entire content of makbet's internal   
-                                   ".cache/events/csv/" dir (this target    
-                                   requires prior MAKBET_CSV=1 usage).        
+    .show-events-dir             - Show entire content of internal            
+                                   ".makbet-cache/events/" dir including    
+                                   all its sub-dirs.                          
+    .show-events-cfg-dir         - Show entire content of internal            
+                                   ".makbet-cache/events/cfg/" dir.         
+    .show-events-csv-dir         - Show entire content of internal            
+                                   ".makbet-cache/events/csv/" dir (this    
+                                   target requires prior MAKBET_CSV=1 usage). 
     .show-merged-csv-events      - Show merged content of all event csv files 
                                    (this target requires prior MAKBET_CSV=1   
                                    usage).                                    
-    .show-prof-dir               - Show entire content of makbet's internal   
-                                   ".cache/prof/" dir including all         
-                                   sub-dirs.                                  
-    .show-prof-cfg-dir           - Show entire content of makbet's internal   
-                                   ".cache/prof/cfg/" dir (this target      
-                                   requires prior MAKBET_PROF=1 usage).       
-    .show-prof-csv-dir           - Show entire content of makbet's internal   
-                                   ".cache/prof/csv/" dir (this target      
-                                   requires prior MAKBET_PROF=1 and           
+    .show-prof-dir               - Show entire content of internal            
+                                   ".makbet-cache/prof/" dir including all  
+                                   its sub-dirs.                              
+    .show-prof-cfg-dir           - Show entire content of internal            
+                                   ".makbet-cache/prof/cfg/" dir (this      
+                                   target requires prior MAKBET_PROF=1 usage).
+    .show-prof-csv-dir           - Show entire content of internal            
+                                   ".makbet-cache/prof/csv/" dir (this      
+                                   target requires prior MAKBET_PROF=1 and    
                                    MAKBET_CSV=1 usage).                       
     .show-merged-csv-profiles    - Show merged content of all profile csv     
                                    files (this target requires prior          

--- a/tests/resources/expected/examples/05.sleep/t01__make
+++ b/tests/resources/expected/examples/05.sleep/t01__make
@@ -18,8 +18,7 @@ All makbet's basic targets defined in /home/user/makbet/makbet.mk:
                                    target "help" above) then append extended
                                    help message containing the list of all    
                                    special makbet's targets.                  
-    makbet-clean                 - Clean entire makbet's internal ".cache/" 
-                                   dir.                                       
+    makbet-clean                 - Clean entire ".makbet-cache/" dir.       
     makbet-version               - Print makbet's version only.               
 
 Examples:                                                                     

--- a/tests/resources/expected/examples/05.sleep/t04__make,makbet-help
+++ b/tests/resources/expected/examples/05.sleep/t04__make,makbet-help
@@ -18,8 +18,7 @@ All makbet's basic targets defined in /home/user/makbet//makbet.mk:
                                    target "help" above) then append extended
                                    help message containing the list of all    
                                    special makbet's targets.                  
-    makbet-clean                 - Clean entire makbet's internal ".cache/" 
-                                   dir.                                       
+    makbet-clean                 - Clean entire ".makbet-cache/" dir.       
     makbet-version               - Print makbet's version only.               
 
 Examples:                                                                     
@@ -33,33 +32,33 @@ Examples:
 
 All makbet's special targets defined in /home/user/makbet//makbet.mk:             
 
-    .show-cache-dir              - Show entire content of makbet's internal   
-                                   ".cache/" dir.                           
-    .show-dot-dir                - Show entire content of makbet's internal   
-                                   ".cache/dot/" dir (this target requires  
-                                   prior MAKBET_DOT=1 usage).                 
+    .show-cache-dir              - Show entire content of internal            
+                                   ".makbet-cache/" dir.                    
+    .show-dot-dir                - Show entire content of internal            
+                                   ".makbet-cache/dot/" dir (this target    
+                                   requires prior MAKBET_DOT=1 usage).        
     .show-merged-dot-results     - Show merged content of all dot files (this 
                                    target requires prior MAKBET_DOT=1 usage). 
-    .show-events-dir             - Show entire content of makbet's internal   
-                                   ".cache/events/" dir including all       
-                                   sub-dirs.                                  
-    .show-events-cfg-dir         - Show entire content of makbet's internal   
-                                   ".cache/events/cfg/" dir.                
-    .show-events-csv-dir         - Show entire content of makbet's internal   
-                                   ".cache/events/csv/" dir (this target    
-                                   requires prior MAKBET_CSV=1 usage).        
+    .show-events-dir             - Show entire content of internal            
+                                   ".makbet-cache/events/" dir including    
+                                   all its sub-dirs.                          
+    .show-events-cfg-dir         - Show entire content of internal            
+                                   ".makbet-cache/events/cfg/" dir.         
+    .show-events-csv-dir         - Show entire content of internal            
+                                   ".makbet-cache/events/csv/" dir (this    
+                                   target requires prior MAKBET_CSV=1 usage). 
     .show-merged-csv-events      - Show merged content of all event csv files 
                                    (this target requires prior MAKBET_CSV=1   
                                    usage).                                    
-    .show-prof-dir               - Show entire content of makbet's internal   
-                                   ".cache/prof/" dir including all         
-                                   sub-dirs.                                  
-    .show-prof-cfg-dir           - Show entire content of makbet's internal   
-                                   ".cache/prof/cfg/" dir (this target      
-                                   requires prior MAKBET_PROF=1 usage).       
-    .show-prof-csv-dir           - Show entire content of makbet's internal   
-                                   ".cache/prof/csv/" dir (this target      
-                                   requires prior MAKBET_PROF=1 and           
+    .show-prof-dir               - Show entire content of internal            
+                                   ".makbet-cache/prof/" dir including all  
+                                   its sub-dirs.                              
+    .show-prof-cfg-dir           - Show entire content of internal            
+                                   ".makbet-cache/prof/cfg/" dir (this      
+                                   target requires prior MAKBET_PROF=1 usage).
+    .show-prof-csv-dir           - Show entire content of internal            
+                                   ".makbet-cache/prof/csv/" dir (this      
+                                   target requires prior MAKBET_PROF=1 and    
                                    MAKBET_CSV=1 usage).                       
     .show-merged-csv-profiles    - Show merged content of all profile csv     
                                    files (this target requires prior          

--- a/tests/resources/expected/examples/06.comments/t01__make
+++ b/tests/resources/expected/examples/06.comments/t01__make
@@ -18,8 +18,7 @@ All makbet's basic targets defined in /home/user/makbet/makbet.mk:
                                    target "help" above) then append extended
                                    help message containing the list of all    
                                    special makbet's targets.                  
-    makbet-clean                 - Clean entire makbet's internal ".cache/" 
-                                   dir.                                       
+    makbet-clean                 - Clean entire ".makbet-cache/" dir.       
     makbet-version               - Print makbet's version only.               
 
 Examples:                                                                     

--- a/tests/resources/expected/examples/06.comments/t02__make,makbet-help
+++ b/tests/resources/expected/examples/06.comments/t02__make,makbet-help
@@ -18,8 +18,7 @@ All makbet's basic targets defined in /home/user/makbet/makbet.mk:
                                    target "help" above) then append extended
                                    help message containing the list of all    
                                    special makbet's targets.                  
-    makbet-clean                 - Clean entire makbet's internal ".cache/" 
-                                   dir.                                       
+    makbet-clean                 - Clean entire ".makbet-cache/" dir.       
     makbet-version               - Print makbet's version only.               
 
 Examples:                                                                     
@@ -33,33 +32,33 @@ Examples:
 
 All makbet's special targets defined in /home/user/makbet/makbet.mk:             
 
-    .show-cache-dir              - Show entire content of makbet's internal   
-                                   ".cache/" dir.                           
-    .show-dot-dir                - Show entire content of makbet's internal   
-                                   ".cache/dot/" dir (this target requires  
-                                   prior MAKBET_DOT=1 usage).                 
+    .show-cache-dir              - Show entire content of internal            
+                                   ".makbet-cache/" dir.                    
+    .show-dot-dir                - Show entire content of internal            
+                                   ".makbet-cache/dot/" dir (this target    
+                                   requires prior MAKBET_DOT=1 usage).        
     .show-merged-dot-results     - Show merged content of all dot files (this 
                                    target requires prior MAKBET_DOT=1 usage). 
-    .show-events-dir             - Show entire content of makbet's internal   
-                                   ".cache/events/" dir including all       
-                                   sub-dirs.                                  
-    .show-events-cfg-dir         - Show entire content of makbet's internal   
-                                   ".cache/events/cfg/" dir.                
-    .show-events-csv-dir         - Show entire content of makbet's internal   
-                                   ".cache/events/csv/" dir (this target    
-                                   requires prior MAKBET_CSV=1 usage).        
+    .show-events-dir             - Show entire content of internal            
+                                   ".makbet-cache/events/" dir including    
+                                   all its sub-dirs.                          
+    .show-events-cfg-dir         - Show entire content of internal            
+                                   ".makbet-cache/events/cfg/" dir.         
+    .show-events-csv-dir         - Show entire content of internal            
+                                   ".makbet-cache/events/csv/" dir (this    
+                                   target requires prior MAKBET_CSV=1 usage). 
     .show-merged-csv-events      - Show merged content of all event csv files 
                                    (this target requires prior MAKBET_CSV=1   
                                    usage).                                    
-    .show-prof-dir               - Show entire content of makbet's internal   
-                                   ".cache/prof/" dir including all         
-                                   sub-dirs.                                  
-    .show-prof-cfg-dir           - Show entire content of makbet's internal   
-                                   ".cache/prof/cfg/" dir (this target      
-                                   requires prior MAKBET_PROF=1 usage).       
-    .show-prof-csv-dir           - Show entire content of makbet's internal   
-                                   ".cache/prof/csv/" dir (this target      
-                                   requires prior MAKBET_PROF=1 and           
+    .show-prof-dir               - Show entire content of internal            
+                                   ".makbet-cache/prof/" dir including all  
+                                   its sub-dirs.                              
+    .show-prof-cfg-dir           - Show entire content of internal            
+                                   ".makbet-cache/prof/cfg/" dir (this      
+                                   target requires prior MAKBET_PROF=1 usage).
+    .show-prof-csv-dir           - Show entire content of internal            
+                                   ".makbet-cache/prof/csv/" dir (this      
+                                   target requires prior MAKBET_PROF=1 and    
                                    MAKBET_CSV=1 usage).                       
     .show-merged-csv-profiles    - Show merged content of all profile csv     
                                    files (this target requires prior          

--- a/tests/resources/expected/t01__make
+++ b/tests/resources/expected/t01__make
@@ -18,8 +18,7 @@ All makbet's basic targets defined in /home/user/makbet//makbet.mk:
                                    target "help" above) then append extended
                                    help message containing the list of all    
                                    special makbet's targets.                  
-    makbet-clean                 - Clean entire makbet's internal ".cache/" 
-                                   dir.                                       
+    makbet-clean                 - Clean entire ".makbet-cache/" dir.       
     makbet-version               - Print makbet's version only.               
 
 Examples:                                                                     

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -14,7 +14,7 @@ readonly CWD="$(pwd)"
 export MAKBET_PATH="$( readlink -f "${CWD}/.." )"
 
 # Export MAKBET_CACHE_DIR variable in addition.
-export MAKBET_CACHE_DIR="${MAKBET_PATH}/.cache"
+export MAKBET_CACHE_DIR="${MAKBET_PATH}/.makbet-cache"
 
 export MAKBET_TESTS_DIR="${MAKBET_PATH}/tests"
 export MAKBET_TESTS_LOGS_DIR="${MAKBET_TESTS_DIR}/logs"

--- a/tests/src/examples/01.dummy/t01__make
+++ b/tests/src/examples/01.dummy/t01__make
@@ -14,12 +14,12 @@ make \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d;47d;54d;61d;68d;75d;82d;89d;96d;103d;117d' \
+        | sed '2d;8d;33d;46d;53d;60d;67d;74d;81d;88d;95d;102d;116d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d;47d;54d;61d;68d;75d;82d;89d;96d;103d;117d' \
+        | sed '2d;8d;33d;46d;53d;60d;67d;74d;81d;88d;95d;102d;116d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/01.dummy/t02__make,-f,Makefile
+++ b/tests/src/examples/01.dummy/t02__make,-f,Makefile
@@ -14,12 +14,12 @@ make -f "${MAKBET_PATH}/examples/01.dummy/Makefile" \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d;47d;54d;61d;68d;75d;82d;89d;96d;103d;117d' \
+        | sed '2d;8d;33d;46d;53d;60d;67d;74d;81d;88d;95d;102d;116d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d;47d;54d;61d;68d;75d;82d;89d;96d;103d;117d' \
+        | sed '2d;8d;33d;46d;53d;60d;67d;74d;81d;88d;95d;102d;116d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/01.dummy/t05__make,-f,Makefile,makbet-help
+++ b/tests/src/examples/01.dummy/t05__make,-f,Makefile,makbet-help
@@ -14,12 +14,12 @@ make -f "${MAKBET_PATH}/examples/01.dummy/Makefile" makbet-help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/02.toolchain-simple/t01__make
+++ b/tests/src/examples/02.toolchain-simple/t01__make
@@ -14,13 +14,13 @@ make \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     )

--- a/tests/src/examples/02.toolchain-simple/t02__make,help
+++ b/tests/src/examples/02.toolchain-simple/t02__make,help
@@ -14,13 +14,13 @@ make help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     )

--- a/tests/src/examples/02.toolchain-simple/t03__make,-f,Makefile
+++ b/tests/src/examples/02.toolchain-simple/t03__make,-f,Makefile
@@ -14,13 +14,13 @@ make -f Makefile \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     )

--- a/tests/src/examples/02.toolchain-simple/t04__make,-f,Makefile
+++ b/tests/src/examples/02.toolchain-simple/t04__make,-f,Makefile
@@ -14,13 +14,13 @@ make -f "examples/02.toolchain-simple/Makefile" \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     )

--- a/tests/src/examples/02.toolchain-simple/t05__make,-f,Makefile,help
+++ b/tests/src/examples/02.toolchain-simple/t05__make,-f,Makefile,help
@@ -14,13 +14,13 @@ make -f "examples/02.toolchain-simple/Makefile" help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     )

--- a/tests/src/examples/02.toolchain-simple/t07__make,makbet-help
+++ b/tests/src/examples/02.toolchain-simple/t07__make,makbet-help
@@ -14,12 +14,12 @@ make makbet-help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/03.toolchain-advanced/t01__make
+++ b/tests/src/examples/03.toolchain-advanced/t01__make
@@ -14,13 +14,13 @@ make \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     )

--- a/tests/src/examples/03.toolchain-advanced/t02__make,help
+++ b/tests/src/examples/03.toolchain-advanced/t02__make,help
@@ -14,13 +14,13 @@ make help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     )

--- a/tests/src/examples/03.toolchain-advanced/t03__make,-f,Makefile,help
+++ b/tests/src/examples/03.toolchain-advanced/t03__make,-f,Makefile,help
@@ -14,13 +14,13 @@ make -f "examples/03.toolchain-advanced/Makefile" help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     )

--- a/tests/src/examples/03.toolchain-advanced/t04__make,-f,Makefile
+++ b/tests/src/examples/03.toolchain-advanced/t04__make,-f,Makefile
@@ -14,13 +14,13 @@ make -f "examples/03.toolchain-advanced/Makefile" \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | grep -v '\- Cmd:  ' \
         | nl -b a \
     )

--- a/tests/src/examples/04.ping-dns-servers/t01__make
+++ b/tests/src/examples/04.ping-dns-servers/t01__make
@@ -14,12 +14,12 @@ make \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/04.ping-dns-servers/t02__make,help
+++ b/tests/src/examples/04.ping-dns-servers/t02__make,help
@@ -14,12 +14,12 @@ make help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/04.ping-dns-servers/t03__make,-f,Makefile,help
+++ b/tests/src/examples/04.ping-dns-servers/t03__make,-f,Makefile,help
@@ -14,12 +14,12 @@ make -f "examples/04.ping-dns-servers/Makefile" help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/04.ping-dns-servers/t04__make,makbet-help
+++ b/tests/src/examples/04.ping-dns-servers/t04__make,makbet-help
@@ -14,12 +14,12 @@ make makbet-help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/05.sleep/t01__make
+++ b/tests/src/examples/05.sleep/t01__make
@@ -14,12 +14,12 @@ make \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d;47d;54d' \
+        | sed '2d;8d;33d;46d;53d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d;47d;54d' \
+        | sed '2d;8d;33d;46d;53d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/05.sleep/t02__make,help
+++ b/tests/src/examples/05.sleep/t02__make,help
@@ -14,12 +14,12 @@ make help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d;47d;54d' \
+        | sed '2d;8d;33d;46d;53d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d;47d;54d' \
+        | sed '2d;8d;33d;46d;53d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/05.sleep/t03__make,-f,Makefile,help
+++ b/tests/src/examples/05.sleep/t03__make,-f,Makefile,help
@@ -14,12 +14,12 @@ make -f "examples/05.sleep/Makefile" help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d;47d;54d' \
+        | sed '2d;8d;33d;46d;53d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d;47d;54d' \
+        | sed '2d;8d;33d;46d;53d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/05.sleep/t04__make,makbet-help
+++ b/tests/src/examples/05.sleep/t04__make,makbet-help
@@ -14,12 +14,12 @@ make makbet-help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d' \
+        | sed '2d;8d;33d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/06.comments/t01__make
+++ b/tests/src/examples/06.comments/t01__make
@@ -14,12 +14,12 @@ make \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d;46d;53d' \
+        | sed '2d;8d;33d;45d;52d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d;46d;53d' \
+        | sed '2d;8d;33d;45d;52d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/06.comments/t02__make,makbet-help
+++ b/tests/src/examples/06.comments/t02__make,makbet-help
@@ -14,12 +14,12 @@ make makbet-help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d;46d;53d' \
+        | sed '2d;8d;33d;45d;52d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d;46d;53d' \
+        | sed '2d;8d;33d;45d;52d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/06.comments/t04__make,-f,Makefile,makbet-help
+++ b/tests/src/examples/06.comments/t04__make,-f,Makefile,makbet-help
@@ -14,12 +14,12 @@ make -f "examples/06.comments/Makefile" makbet-help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;34d;46d;53d' \
+        | sed '2d;8d;33d;45d;52d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;34d;46d;53d' \
+        | sed '2d;8d;33d;45d;52d' \
         | nl -b a \
     )
 readonly __rc=$?

--- a/tests/src/examples/06.comments/t05__make,help
+++ b/tests/src/examples/06.comments/t05__make,help
@@ -14,12 +14,12 @@ make help \
 diff -u -s \
     <( \
         cat "${output_file}" \
-        | sed '2d;8d;33d;46d;53d' \
+        | sed '2d;8d;33d;45d;52d' \
         | nl -b a \
     ) \
     <( \
         cat "${expected_file}" \
-        | sed '2d;8d;33d;46d;53d' \
+        | sed '2d;8d;33d;45d;52d' \
         | nl -b a \
     )
 readonly __rc=$?


### PR DESCRIPTION
Change the name of makbet's internal cache directory from ".cache"
to ".makbet-cache" to make it more unique and recognizable.  Adapt
all references in few README.rst files (and some other files too).
Update all related tests as well.

Resolve #152.
