### PR TITLE
[#154] Replace "End of File" with "EOF"

### DIFF
--- a/.github/workflows/CI-tests.yml
+++ b/.github/workflows/CI-tests.yml
@@ -70,4 +70,4 @@ jobs:
             tests/output/
 
 
-# End of file
+# EOF

--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,4 @@ tests/logs/
 tests/output/
 
 
-# End of file
+# EOF

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -163,4 +163,4 @@ https://github.com/github/hub/issues/1241) we are merging code locally
 without using GitHub GUI.
 
 
-.. End of file
+.. EOF

--- a/README.rst
+++ b/README.rst
@@ -306,7 +306,7 @@ the **DOT** results which can be used for further processing:
   }
 
 
-  // End of file
+  // EOF
 
   [user@localhost 01.dummy]$
 
@@ -736,4 +736,4 @@ Mission statement
 *"What's done, is done."* - William Shakespeare, **Macbeth**.
 
 
-.. End of file
+.. EOF

--- a/core/README.rst
+++ b/core/README.rst
@@ -98,4 +98,4 @@ where:
 - ``README.rst`` - The file you are reading now.
 
 
-.. End of file
+.. EOF

--- a/core/__check_gnu_make_version
+++ b/core/__check_gnu_make_version
@@ -37,4 +37,4 @@ else
 fi
 
 
-# End of file
+# EOF

--- a/core/__convert_cfg2csv
+++ b/core/__convert_cfg2csv
@@ -22,4 +22,4 @@ cat "${1}" | cut -d '=' -f2 | tr "\n" "${4}" >> "${2}"
 echo "" >> "${2}"
 
 
-# End of file
+# EOF

--- a/core/__count_tasks
+++ b/core/__count_tasks
@@ -13,4 +13,4 @@ set -u
 grep -c '^$(eval $(call TASK_template' "${1}"
 
 
-# End of file
+# EOF

--- a/core/__get_makbet_version
+++ b/core/__get_makbet_version
@@ -19,4 +19,4 @@ fi
 set -e
 
 
-# End of file
+# EOF

--- a/core/__print_task_details
+++ b/core/__print_task_details
@@ -20,4 +20,4 @@ echo "TASK_CMD = ${4:-"None"}"
 echo "TASK_CMD_OPTS = ${5:-"None"}"
 
 
-# End of file
+# EOF

--- a/core/__save_dot_file
+++ b/core/__save_dot_file
@@ -37,4 +37,4 @@ else
 fi
 
 
-# End of file
+# EOF

--- a/core/__save_task_event
+++ b/core/__save_task_event
@@ -37,4 +37,4 @@ echo "TASK_DATE_TIME_${7}=\"${NOW}\"" >> "${6}"
 echo -e "\n${NOW_SHORT} [INFO]: Task \"${2}\" (TASK_ID: ${1}) ${7,,}.\n"
 
 
-# End of file
+# EOF

--- a/core/__save_task_profile
+++ b/core/__save_task_profile
@@ -53,4 +53,4 @@ echo "T2 = ${T2}"
 echo "T2 - T1 = ${TASK_DURATION}"
 
 
-# End of file
+# EOF

--- a/docs/Parallelism/README.rst
+++ b/docs/Parallelism/README.rst
@@ -427,4 +427,4 @@ the best and optimal tasks combination for big projects.
 |
 
 
-.. End of file
+.. EOF

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -59,4 +59,4 @@ where:
 - ``README.rst`` - The file you are reading now.
 
 
-.. End of file
+.. EOF

--- a/docs/TASK_template/README.rst
+++ b/docs/TASK_template/README.rst
@@ -238,4 +238,4 @@ The meanings of all parameters are:
 - http://make.mad-scientist.net/the-eval-function/
 
 
-.. End of file
+.. EOF

--- a/examples/01.dummy/Makefile
+++ b/examples/01.dummy/Makefile
@@ -108,4 +108,4 @@ $(eval $(call TASK_template, \
 ALL: task-F
 
 
-# End of file
+# EOF

--- a/examples/01.dummy/README.rst
+++ b/examples/01.dummy/README.rst
@@ -10,4 +10,4 @@ script), therefore this example can be run at any time with minimal
 requirements and effort.
 
 
-.. End of file
+.. EOF

--- a/examples/01.dummy/results/output.dot
+++ b/examples/01.dummy/results/output.dot
@@ -103,4 +103,4 @@ node [shape="box" style="rounded, bold, filled" fillcolor="azure"];
 }
 
 
-// End of file
+// EOF

--- a/examples/01.dummy/tasks/generic-task
+++ b/examples/01.dummy/tasks/generic-task
@@ -20,4 +20,4 @@ fi
 exit "${EXIT_CODE}"
 
 
-# End of file
+# EOF

--- a/examples/02.toolchain-simple/Makefile
+++ b/examples/02.toolchain-simple/Makefile
@@ -254,4 +254,4 @@ ALL: \
 	print-all-versions
 
 
-# End of file
+# EOF

--- a/examples/02.toolchain-simple/README.rst
+++ b/examples/02.toolchain-simple/README.rst
@@ -15,4 +15,4 @@ The ``Makefile`` file in current directory contains all tasks needed
 for downloading the sources and building every tool listed above.
 
 
-.. End of file
+.. EOF

--- a/examples/02.toolchain-simple/results/output.dot
+++ b/examples/02.toolchain-simple/results/output.dot
@@ -210,4 +210,4 @@ node [shape="box" style="rounded, bold, filled" fillcolor="azure"];
 }
 
 
-// End of file
+// EOF

--- a/examples/03.toolchain-advanced/Makefile
+++ b/examples/03.toolchain-advanced/Makefile
@@ -263,4 +263,4 @@ all: \
 	print-all-versions
 
 
-# End of file
+# EOF

--- a/examples/03.toolchain-advanced/README.rst
+++ b/examples/03.toolchain-advanced/README.rst
@@ -12,4 +12,4 @@ purposes.  As expected final results for both **02.toolchain-simple** and
 **03.toolchain-advanced** should be the same.
 
 
-.. End of file
+.. EOF

--- a/examples/03.toolchain-advanced/results/output.dot
+++ b/examples/03.toolchain-advanced/results/output.dot
@@ -191,4 +191,4 @@ node [shape="box" style="rounded, bold, filled" fillcolor="azure"];
 }
 
 
-// End of file
+// EOF

--- a/examples/04.ping-dns-servers/Makefile
+++ b/examples/04.ping-dns-servers/Makefile
@@ -55,4 +55,4 @@ $(eval $(call TASK_template, \
 ))
 
 
-# End of file
+# EOF

--- a/examples/04.ping-dns-servers/README.rst
+++ b/examples/04.ping-dns-servers/README.rst
@@ -16,4 +16,4 @@ macro.  Input params for ``ping`` command can be different for different
 servers.
 
 
-.. End of file
+.. EOF

--- a/examples/04.ping-dns-servers/results/output.dot
+++ b/examples/04.ping-dns-servers/results/output.dot
@@ -52,4 +52,4 @@ node [shape="box" style="rounded, bold, filled" fillcolor="azure"];
 }
 
 
-// End of file
+// EOF

--- a/examples/05.sleep/Makefile
+++ b/examples/05.sleep/Makefile
@@ -60,4 +60,4 @@ $(eval $(call TASK_template, \
 ))
 
 
-# End of file
+# EOF

--- a/examples/05.sleep/README.rst
+++ b/examples/05.sleep/README.rst
@@ -11,4 +11,4 @@ command.  In general if jobs value (``-j``) will be greater than 1, tasks
 will be executed simultaneously.
 
 
-.. End of file
+.. EOF

--- a/examples/05.sleep/results/output.dot
+++ b/examples/05.sleep/results/output.dot
@@ -68,4 +68,4 @@ node [shape="box" style="rounded, bold, filled" fillcolor="azure"];
 }
 
 
-// End of file
+// EOF

--- a/examples/06.comments/Makefile
+++ b/examples/06.comments/Makefile
@@ -42,4 +42,4 @@ endif
 # ))
 
 
-# End of file
+# EOF

--- a/examples/06.comments/README.rst
+++ b/examples/06.comments/README.rst
@@ -15,4 +15,4 @@ also correctly.  The aim of this example is to show how to properly
 comment tasks out inside inside scenario ``Makefile``.
 
 
-.. End of file
+.. EOF

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -209,4 +209,4 @@ where:
 - ``README.rst`` - The file you are reading now.
 
 
-.. End of file
+.. EOF

--- a/examples/lib/tasks/build-scripts/build-doxygen
+++ b/examples/lib/tasks/build-scripts/build-doxygen
@@ -24,4 +24,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/build-scripts/build-git
+++ b/examples/lib/tasks/build-scripts/build-git
@@ -21,4 +21,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/build-scripts/build-kcov
+++ b/examples/lib/tasks/build-scripts/build-kcov
@@ -24,4 +24,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/build-scripts/build-make
+++ b/examples/lib/tasks/build-scripts/build-make
@@ -22,4 +22,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/build-scripts/build-python
+++ b/examples/lib/tasks/build-scripts/build-python
@@ -22,4 +22,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/common/check-dirs
+++ b/examples/lib/tasks/common/check-dirs
@@ -23,4 +23,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/common/check-files
+++ b/examples/lib/tasks/common/check-files
@@ -23,4 +23,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/common/create-dir-structure
+++ b/examples/lib/tasks/common/create-dir-structure
@@ -16,4 +16,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/common/delay
+++ b/examples/lib/tasks/common/delay
@@ -19,4 +19,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/common/download-file
+++ b/examples/lib/tasks/common/download-file
@@ -17,4 +17,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/common/exec-cmd
+++ b/examples/lib/tasks/common/exec-cmd
@@ -16,4 +16,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/common/show-free-space
+++ b/examples/lib/tasks/common/show-free-space
@@ -16,4 +16,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/common/show-uname
+++ b/examples/lib/tasks/common/show-uname
@@ -16,4 +16,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/common/show-uptime
+++ b/examples/lib/tasks/common/show-uptime
@@ -16,4 +16,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/common/uncompress-tgz-file
+++ b/examples/lib/tasks/common/uncompress-tgz-file
@@ -17,4 +17,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/common/uncompress-txz-file
+++ b/examples/lib/tasks/common/uncompress-txz-file
@@ -17,4 +17,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/examples/lib/tasks/common/uncompress-zip-file
+++ b/examples/lib/tasks/common/uncompress-zip-file
@@ -17,4 +17,4 @@ then
 fi
 
 
-# End of file
+# EOF

--- a/makbet.mk
+++ b/makbet.mk
@@ -373,7 +373,7 @@ endef
 	@echo "}"
 	@echo
 	@echo
-	@echo "// End of file"
+	@echo "// EOF"
 	@echo
 
 
@@ -587,4 +587,4 @@ scenario-help::
 help: main-help scenario-help
 
 
-# End of file
+# EOF

--- a/templates/scenario/Makefile
+++ b/templates/scenario/Makefile
@@ -44,4 +44,4 @@ $(eval $(call TASK_template, \
 ))
 
 
-# End of file
+# EOF

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -99,4 +99,4 @@ where:
   all tests from ``src/`` directory structure.
 
 
-.. End of file
+.. EOF

--- a/tests/run-tests.sh
+++ b/tests/run-tests.sh
@@ -149,4 +149,4 @@ echo -e "\n\n[INFO]: Script ${0} completed.\n"
 exit "${__rc}"
 
 
-# End of file
+# EOF

--- a/tests/src/examples/01.dummy/t01__make
+++ b/tests/src/examples/01.dummy/t01__make
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/01.dummy/t02__make,-f,Makefile
+++ b/tests/src/examples/01.dummy/t02__make,-f,Makefile
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/01.dummy/t03__make,-f,Makefile
+++ b/tests/src/examples/01.dummy/t03__make,-f,Makefile
@@ -25,4 +25,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/01.dummy/t04__make,-f,Makefile,scenario-help
+++ b/tests/src/examples/01.dummy/t04__make,-f,Makefile,scenario-help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/01.dummy/t05__make,-f,Makefile,makbet-help
+++ b/tests/src/examples/01.dummy/t05__make,-f,Makefile,makbet-help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/01.dummy/t06__make,MAKBET_DOT=1,all,.show-merged-dot-results
+++ b/tests/src/examples/01.dummy/t06__make,MAKBET_DOT=1,all,.show-merged-dot-results
@@ -28,4 +28,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/01.dummy/t07__make,-j8,MAKBET_DOT=1,all,make,.show-merged-dot-results
+++ b/tests/src/examples/01.dummy/t07__make,-j8,MAKBET_DOT=1,all,make,.show-merged-dot-results
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/01.dummy/t08__make,MAKBET_CSV=1,all,.show-merged-csv-events
+++ b/tests/src/examples/01.dummy/t08__make,MAKBET_CSV=1,all,.show-merged-csv-events
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/01.dummy/t09__make,-j8,MAKBET_CSV=1,all,make,.show-merged-csv-events
+++ b/tests/src/examples/01.dummy/t09__make,-j8,MAKBET_CSV=1,all,make,.show-merged-csv-events
@@ -30,4 +30,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/01.dummy/t10__make,MAKBET_DOT=1,all
+++ b/tests/src/examples/01.dummy/t10__make,MAKBET_DOT=1,all
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/01.dummy/t11__make,MAKBET_CSV=1,all
+++ b/tests/src/examples/01.dummy/t11__make,MAKBET_CSV=1,all
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/01.dummy/t12__make,MAKBET_CSV=1,MAKBET_DOT=1,all
+++ b/tests/src/examples/01.dummy/t12__make,MAKBET_CSV=1,MAKBET_DOT=1,all
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/01.dummy/t13__make,-j8,MAKBET_CSV=1,all,make,.show-merged-csv-events
+++ b/tests/src/examples/01.dummy/t13__make,-j8,MAKBET_CSV=1,all,make,.show-merged-csv-events
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/02.toolchain-simple/t01__make
+++ b/tests/src/examples/02.toolchain-simple/t01__make
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/02.toolchain-simple/t02__make,help
+++ b/tests/src/examples/02.toolchain-simple/t02__make,help
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/02.toolchain-simple/t03__make,-f,Makefile
+++ b/tests/src/examples/02.toolchain-simple/t03__make,-f,Makefile
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/02.toolchain-simple/t04__make,-f,Makefile
+++ b/tests/src/examples/02.toolchain-simple/t04__make,-f,Makefile
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/02.toolchain-simple/t05__make,-f,Makefile,help
+++ b/tests/src/examples/02.toolchain-simple/t05__make,-f,Makefile,help
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/02.toolchain-simple/t06__make
+++ b/tests/src/examples/02.toolchain-simple/t06__make
@@ -26,4 +26,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/02.toolchain-simple/t07__make,makbet-help
+++ b/tests/src/examples/02.toolchain-simple/t07__make,makbet-help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/02.toolchain-simple/t08__make,-f,Makefile,scenario-help
+++ b/tests/src/examples/02.toolchain-simple/t08__make,-f,Makefile,scenario-help
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/03.toolchain-advanced/t01__make
+++ b/tests/src/examples/03.toolchain-advanced/t01__make
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/03.toolchain-advanced/t02__make,help
+++ b/tests/src/examples/03.toolchain-advanced/t02__make,help
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/03.toolchain-advanced/t03__make,-f,Makefile,help
+++ b/tests/src/examples/03.toolchain-advanced/t03__make,-f,Makefile,help
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/03.toolchain-advanced/t04__make,-f,Makefile
+++ b/tests/src/examples/03.toolchain-advanced/t04__make,-f,Makefile
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/03.toolchain-advanced/t05__make,-f,Makefile
+++ b/tests/src/examples/03.toolchain-advanced/t05__make,-f,Makefile
@@ -25,4 +25,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/03.toolchain-advanced/t06__make,-f,Makefile
+++ b/tests/src/examples/03.toolchain-advanced/t06__make,-f,Makefile
@@ -25,4 +25,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/03.toolchain-advanced/t07__make,-f,Makefile,scenario-help
+++ b/tests/src/examples/03.toolchain-advanced/t07__make,-f,Makefile,scenario-help
@@ -26,4 +26,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/03.toolchain-advanced/t08__make,-f,Makefile,scenario-help
+++ b/tests/src/examples/03.toolchain-advanced/t08__make,-f,Makefile,scenario-help
@@ -29,4 +29,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/04.ping-dns-servers/t01__make
+++ b/tests/src/examples/04.ping-dns-servers/t01__make
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/04.ping-dns-servers/t02__make,help
+++ b/tests/src/examples/04.ping-dns-servers/t02__make,help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/04.ping-dns-servers/t03__make,-f,Makefile,help
+++ b/tests/src/examples/04.ping-dns-servers/t03__make,-f,Makefile,help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/04.ping-dns-servers/t04__make,makbet-help
+++ b/tests/src/examples/04.ping-dns-servers/t04__make,makbet-help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/04.ping-dns-servers/t05__make,-f,Makefile,scenario-help
+++ b/tests/src/examples/04.ping-dns-servers/t05__make,-f,Makefile,scenario-help
@@ -26,4 +26,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/05.sleep/t01__make
+++ b/tests/src/examples/05.sleep/t01__make
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/05.sleep/t02__make,help
+++ b/tests/src/examples/05.sleep/t02__make,help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/05.sleep/t03__make,-f,Makefile,help
+++ b/tests/src/examples/05.sleep/t03__make,-f,Makefile,help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/05.sleep/t04__make,makbet-help
+++ b/tests/src/examples/05.sleep/t04__make,makbet-help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/05.sleep/t05__make,-f,Makefile,scenario-help
+++ b/tests/src/examples/05.sleep/t05__make,-f,Makefile,scenario-help
@@ -26,4 +26,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/05.sleep/t06__make,all
+++ b/tests/src/examples/05.sleep/t06__make,all
@@ -25,4 +25,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/06.comments/t01__make
+++ b/tests/src/examples/06.comments/t01__make
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/06.comments/t02__make,makbet-help
+++ b/tests/src/examples/06.comments/t02__make,makbet-help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/06.comments/t03__make,-f,Makefile,scenario-help
+++ b/tests/src/examples/06.comments/t03__make,-f,Makefile,scenario-help
@@ -25,4 +25,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/06.comments/t04__make,-f,Makefile,makbet-help
+++ b/tests/src/examples/06.comments/t04__make,-f,Makefile,makbet-help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/06.comments/t05__make,help
+++ b/tests/src/examples/06.comments/t05__make,help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/06.comments/t06__make,scenario-help
+++ b/tests/src/examples/06.comments/t06__make,scenario-help
@@ -25,4 +25,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/06.comments/t07__make,MAKBET_VERBOSE=0,scenario-help
+++ b/tests/src/examples/06.comments/t07__make,MAKBET_VERBOSE=0,scenario-help
@@ -25,4 +25,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/examples/06.comments/t08__make,-f,Makefile,MAKBET_VERBOSE=0,scenario-help
+++ b/tests/src/examples/06.comments/t08__make,-f,Makefile,MAKBET_VERBOSE=0,scenario-help
@@ -25,4 +25,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t01__make
+++ b/tests/src/t01__make
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t02__make,-f,makbet.mk
+++ b/tests/src/t02__make,-f,makbet.mk
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t03__make,-f,makbet.mk
+++ b/tests/src/t03__make,-f,makbet.mk
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t04__make,-f,Makefile
+++ b/tests/src/t04__make,-f,Makefile
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t05__make,-f,Makefile
+++ b/tests/src/t05__make,-f,Makefile
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t06__make,-f,Makefile
+++ b/tests/src/t06__make,-f,Makefile
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t07__make,-f,makbet.mk
+++ b/tests/src/t07__make,-f,makbet.mk
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t08__make,-f,makbet.mk
+++ b/tests/src/t08__make,-f,makbet.mk
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t09__make,-f,makbet.mk,scenario-help
+++ b/tests/src/t09__make,-f,makbet.mk,scenario-help
@@ -23,4 +23,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t10__make,help
+++ b/tests/src/t10__make,help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t11__make,-f,makbet.mk,help
+++ b/tests/src/t11__make,-f,makbet.mk,help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t12__make,-f,makbet.mk,MAKBET_VERBOSE=0
+++ b/tests/src/t12__make,-f,makbet.mk,MAKBET_VERBOSE=0
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t13__make,-f,makbet.mk,MAKBET_VERBOSE=0,help
+++ b/tests/src/t13__make,-f,makbet.mk,MAKBET_VERBOSE=0,help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t14__make,MAKBET_VERBOSE=0
+++ b/tests/src/t14__make,MAKBET_VERBOSE=0
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t15__make,MAKBET_VERBOSE=0,help
+++ b/tests/src/t15__make,MAKBET_VERBOSE=0,help
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF

--- a/tests/src/t16__make,-f,Makefile,MAKBET_VERBOSE=0
+++ b/tests/src/t16__make,-f,Makefile,MAKBET_VERBOSE=0
@@ -27,4 +27,4 @@ popd > /dev/null
 exit ${__rc}
 
 
-# End of file
+# EOF


### PR DESCRIPTION
Find all "End of File" occurrences in all files and replace them
with simply "EOF" (the meaning is the same, but form is much much
shorter).

Resolve #154.
